### PR TITLE
Add support for model saving to non-existant subdirs

### DIFF
--- a/gordo_components/builder/build_model.py
+++ b/gordo_components/builder/build_model.py
@@ -29,6 +29,7 @@ def build_model(output_dir, model_config, data_config):
     model.fit(X, y)
 
     filename = 'model.h5' if hasattr(model._model, 'save') else 'model.pkl'
+    os.makedirs(output_dir, exist_ok=True)  # Ok if some dirs exist
     outpath = os.path.join(output_dir, filename)
 
     # TODO: Get better model saving ops.

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+
+import unittest
+import os
+from tempfile import TemporaryDirectory
+
+
+class ModelBuilderTestCase(unittest.TestCase):
+    """
+    Test functionality of the builder processes
+    """
+
+    def test_output_dir(self):
+        """
+        Test building of model will create subdirectories for model saving if needed.
+        """
+        from gordo_components.builder import build_model
+
+        with TemporaryDirectory() as tmpdir:
+
+            model_config = {'type': 'keras'}
+            data_config = {'type': 'random'}
+            output_dir = os.path.join(tmpdir, 'some', 'sub', 'directories')
+
+            build_model(output_dir=output_dir, 
+                        model_config=model_config, 
+                        data_config=data_config)
+
+            # Assert the model was saved at the location specified
+            saved_model = os.path.join(output_dir, 'model.pkl')
+            self.assertTrue(os.path.exists(saved_model))


### PR DESCRIPTION
Closes #6 

If model builder component flow gets an `OUTPUT_DIR=/directory/and/subdirs/which/do/not/exist` then the model builder will automatically create those sub directories.