### PR TITLE
Dockerfiles: Improve layer cacheability for faster builds

### DIFF
--- a/Dockerfile-ModelBuilder
+++ b/Dockerfile-ModelBuilder
@@ -2,6 +2,10 @@ FROM python:3.6.6-slim-stretch
 
 RUN mkdir /data
 
+# Install requirements separately for improved docker caching
+COPY requirements.txt /code/
+RUN pip install -r /code/requirements.txt
+
 # Copy source code
 COPY . /code
 

--- a/Dockerfile-ModelServer
+++ b/Dockerfile-ModelServer
@@ -1,5 +1,10 @@
 FROM seldonio/seldon-core-s2i-python3
 
 RUN mkdir /code
+
+# Install requirements separately for improved docker caching
+COPY requirements.txt /code/
+RUN pip install -r /code/requirements.txt
+
 COPY . /code
 RUN cd /code && pip install .


### PR DESCRIPTION
Added requirements.txt and pip-installed it as seperate commands
so those layers will be re-used if all that has changed is the
code. Does nothing on travis (since it uses a fresh machine each time),
but it makes local builds much faster.