### PR TITLE
Add doc tests to standard testing

### DIFF
--- a/gordo_components/serializer/pipeline_from_definition.py
+++ b/gordo_components/serializer/pipeline_from_definition.py
@@ -16,23 +16,24 @@ def pipeline_from_definition(pipe_definition: dict) -> Union[FeatureUnion, Pipel
 
     Example:
     >>> import yaml
-    >>> from gordo_components.serializer import pipeline_from_definition
+    >>> from gordo_components import serializer
     >>> raw_config = '''
     ... sklearn.pipeline.Pipeline:
     ...         steps:
-    ...             - sklearn.decomposition.PCA:
+    ...             - sklearn.decomposition.pca.PCA:
     ...                 n_components: 3
     ...             - sklearn.pipeline.FeatureUnion:
-    ...                 - sklearn.decomposition.PCA:
+    ...                 - sklearn.decomposition.pca.PCA:
     ...                     n_components: 3
     ...                 - sklearn.pipeline.Pipeline:
-    ...                     - sklearn.preprocessing.MinMaxScaler
-    ...                     - sklearn.decomposition.TruncatedSVD:
+    ...                     - sklearn.preprocessing.data.MinMaxScaler
+    ...                     - sklearn.decomposition.truncated_svd.TruncatedSVD:
     ...                         n_components: 2
-    ...             - sklearn.ensemble.RandomForestClassifier:
-    ...         max_depth: 3'''
+    ...             - sklearn.ensemble.forest.RandomForestClassifier:
+    ...                 max_depth: 3
+    ... '''
     >>> config = yaml.load(raw_config)
-    >>> scikit_learn_pipeline = pipeline_from_definition(config)
+    >>> scikit_learn_pipeline = serializer.pipeline_from_definition(config)
 
 
     Parameters

--- a/gordo_components/serializer/serializer.py
+++ b/gordo_components/serializer/serializer.py
@@ -144,7 +144,7 @@ def dump(obj: object, dest_dir: str):
     Example:
 
     >>> from sklearn.pipeline import Pipeline
-    >>> from sklearn.preprocessing import PCA
+    >>> from sklearn.decomposition import PCA
     >>> from gordo_components.model.models import KerasModel
     >>> from gordo_components import serializer
     >>> pipe = Pipeline([
@@ -153,8 +153,8 @@ def dump(obj: object, dest_dir: str):
     ...     # KerasModel implements both `save_to_dir` and `load_from_dir`
     ...     ('model', KerasModel(kind='feedforward_symetric'))
     ... ])
-    >>> serializer.dump(obj=pipe, dest_dir='/my-model')
-    >>> pipe_clone = serializer.load(source_dir='/my-model')
+    >>> serializer.dump(obj=pipe, dest_dir='/tmp/my-model')
+    >>> pipe_clone = serializer.load(source_dir='/tmp/my-model')
 
     Parameters
     ----------

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 [aliases]
-test = pytest --addopts "-vs --log-cli-level=INFO"
+test = pytest --addopts "-vs --doctest-modules --log-cli-level=INFO"
 testpipetranslator = pytest --addopts "-vs -k pipe --log-cli-level=INFO"


### PR DESCRIPTION
Because we don't mess around with our examples.  <( ' ' <)  <( ' ' )>  (> ' ')>