### PR TITLE
Add TF graph & bump seldon serving image -> 0.3

### DIFF
--- a/Dockerfile-ModelBuilder
+++ b/Dockerfile-ModelBuilder
@@ -6,8 +6,9 @@ COPY . /code
 COPY .git /code/
 
 WORKDIR /code
-RUN python setup.py sdist && \
-    mv /code/dist/$(ls /code/dist | head -1) /code/dist/gordo-components-packed.tar.gz
+RUN rm -rf /code/dist \
+    && python setup.py sdist \
+    && mv /code/dist/$(ls /code/dist | head -1) /code/dist/gordo-components-packed.tar.gz
 
 FROM python:3.6.6-slim-stretch
 

--- a/Dockerfile-ModelServer
+++ b/Dockerfile-ModelServer
@@ -6,10 +6,11 @@ COPY . /code
 COPY .git /code/
 
 WORKDIR /code
-RUN python setup.py sdist && \
-    mv /code/dist/$(ls /code/dist | head -1) /code/dist/gordo-components-packed.tar.gz
+RUN rm -rf /code/dist \
+    && python setup.py sdist \
+    && mv /code/dist/$(ls /code/dist | head -1) /code/dist/gordo-components-packed.tar.gz
 
-FROM seldonio/seldon-core-s2i-python3
+FROM seldonio/seldon-core-s2i-python3:0.3
 
 # Install requirements separately for improved docker caching
 COPY requirements.txt /code/

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ push-builder: model-builder
 push-dev-images: push-builder push-server
 
 push-prod-images: export GORDO_PROD_MODE:="true"
-push-prod-images:	push-builder push-server
+push-prod-images: push-builder push-server
 
 # Make the python source distribution
 sdist:

--- a/gordo_components/runtime/SeldonModel.py
+++ b/gordo_components/runtime/SeldonModel.py
@@ -2,7 +2,6 @@
 
 import os
 import logging
-
 from gordo_components import serializer
 
 logger = logging.getLogger(__name__)
@@ -27,6 +26,7 @@ class SeldonModel:
                 f'The supplied directory: "{model_location}" does not exist!')
 
         logger.info(f'Loading up serialized model from dir: {model_location}')
+
         self.model = serializer.load(model_location)
         logger.info(f'Model loaded successfully, ready to serve predictions!')
 


### PR DESCRIPTION
Will close #43 

This fixes the detached graph found when upgrading seldon serving image to 0.3, which was _probably_ hidden by the older seldon image because it was indexing into something which didn't exist, because the model itself failed.

