### PR TITLE
Support FunctionTransformer steps in config

### DIFF
--- a/gordo_components/model/transformer_funcs/general.py
+++ b/gordo_components/model/transformer_funcs/general.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+
+"""
+Functions to be used within sklearn's FunctionTransformer
+https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.FunctionTransformer.html
+
+Each function SHALL take an X, and optionally a y.
+
+Functions CAN take additional arguments which should be given during the initialization of the FunctionTransformer
+
+Example:
+
+>>> from sklearn.preprocessing import FunctionTransformer
+>>> import numpy as np
+>>> def my_function(X, another_arg):
+...     # Some fancy X manipulation...
+...     return X
+>>> transformer = FunctionTransformer(func=my_function, kw_args={'another_arg': 'this thing'})
+>>> out = transformer.fit_transform(np.random.random(100).reshape(10, 10))
+"""
+
+
+def multiply_by(X, factor):
+    """
+    Multiplies X by a given factor
+    """
+    return X * factor

--- a/tests/test_serializer_into_definition.py
+++ b/tests/test_serializer_into_definition.py
@@ -7,7 +7,7 @@ import io
 
 from sklearn.pipeline import Pipeline, FeatureUnion
 from sklearn.decomposition import TruncatedSVD, PCA
-from sklearn.preprocessing import MinMaxScaler
+from sklearn.preprocessing import MinMaxScaler, FunctionTransformer
 
 from gordo_components.model.models import KerasAutoEncoder
 from gordo_components.serializer import pipeline_into_definition, pipeline_from_definition
@@ -135,6 +135,7 @@ class PipelineToConfigTestCase(unittest.TestCase):
         """
         Pass Pipeline into definition, and then from that definition
         """
+        from gordo_components.model.transformer_funcs.general import multiply_by
         pipe = Pipeline([
             ('step_0', PCA(n_components=2)),
             ('step_1', FeatureUnion([
@@ -144,7 +145,8 @@ class PipelineToConfigTestCase(unittest.TestCase):
                     ('step_1', TruncatedSVD(n_components=2))
                 ]))
             ])),
-            ('step_2', KerasAutoEncoder(kind='feedforward_symetric'))
+            ('step_2', FunctionTransformer(func=multiply_by, kw_args={'factor': 1})),
+            ('step_3', KerasAutoEncoder(kind='feedforward_symetric'))
         ])
 
         pipeline_from_definition(pipeline_into_definition(pipe))
@@ -165,6 +167,13 @@ class PipelineToConfigTestCase(unittest.TestCase):
                         tol: 0.0
                         iterated_power: auto
                         random_state:
+                    - sklearn.preprocessing._function_transformer.FunctionTransformer:
+                        func: gordo_components.model.transformer_funcs.general.multiply_by
+                        kw_args:
+                            factor: 1
+                        inverse_func: gordo_components.model.transformer_funcs.general.multiply_by
+                        inv_kw_args:
+                            factor: 1
                     - sklearn.pipeline.FeatureUnion:
                         transformer_list:
                         - sklearn.decomposition.pca.PCA:

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+
+import unittest
+import numpy as np
+
+from sklearn.preprocessing import FunctionTransformer
+from sklearn.pipeline import Pipeline
+from sklearn.decomposition import PCA
+
+
+class GordoFunctionTransformerFuncsTestCase(unittest.TestCase):
+    """
+    Test all functions within gordo_components meants for use in a Scikit-Learn
+    FunctionTransformer work as expected
+    """
+
+    def _validate_transformer(self, transformer):
+        """
+        Inserts a transformer into the middle of a pipeline and runs it
+        """
+        pipe = Pipeline([
+            ('pca1', PCA()),
+            ('custom', transformer),
+            ('pca2', PCA())
+        ])
+        X = np.random.random(size=100).reshape(10, 10)
+        pipe.fit_transform(X)
+
+    def test_multiply_by_function_transformer(self):
+        from gordo_components.model.transformer_funcs.general import multiply_by
+
+        # Provide a require argument
+        tf = FunctionTransformer(func=multiply_by, kw_args={'factor': 2})
+        self._validate_transformer(tf)
+
+        # Ignore the required argument
+        tf = FunctionTransformer(func=multiply_by)
+        with self.assertRaises(TypeError):
+            self._validate_transformer(tf)


### PR DESCRIPTION
Will close #49 

Allow config files to support `FunctionTransformer` definitions, where the `func` parameter is a function held inside of gordo_components and not some random function. 