### PR TITLE
Update watchman to just use target names

### DIFF
--- a/gordo_components/cli.py
+++ b/gordo_components/cli.py
@@ -83,17 +83,12 @@ def run_server_cli(host, port):
 @click.command("run-watchman")
 @click.argument("project-name", envvar="PROJECT_NAME", type=str)
 @click.argument("target-names", envvar="TARGET_NAMES", type=ast.literal_eval)
-@click.argument(
-    "target-names-sanitized", envvar="TARGET_NAMES_SANITIZED", type=ast.literal_eval
-)
 @click.option(
     "--host", type=str, help="The host to run the server on.", default="0.0.0.0"
 )
 @click.option("--port", type=int, help="The port to run the server on.", default=5555)
 @click.option("--debug", type=bool, help="Run in debug mode", default=False)
-def run_watchman_cli(
-    project_name, target_names, target_names_sanitized, host, port, debug
-):
+def run_watchman_cli(project_name, target_names, host, port, debug):
     """
     Start the Gordo Watchman server for this project. Which is responsible
     for dynamically comparing expected URLs derived from a project config fle
@@ -103,11 +98,8 @@ def run_watchman_cli(
     Must have the following environment variables set:
         PROJECT_NAME: project_name for the config file
         TARGET_NAMES: A list of non-sanitized machine / target names
-        TARGET_NAMES_SANITIZED: Same list of names, only sanitized
     """
-    watchman.server.run_server(
-        host, port, debug, project_name, target_names, target_names_sanitized
-    )
+    watchman.server.run_server(host, port, debug, project_name, target_names)
 
 
 gordo.add_command(build)

--- a/gordo_components/watchman/server.py
+++ b/gordo_components/watchman/server.py
@@ -61,11 +61,7 @@ def healthcheck():
     return payload, 200
 
 
-def build_app(
-    project_name: str,
-    target_names: Iterable[str],
-    target_names_sanitized: Iterable[str],
-):
+def build_app(project_name: str, target_names: Iterable[str]):
     """
     Build app and any associated routes
     """
@@ -73,8 +69,8 @@ def build_app(
     # Precompute list of expected endpoints from config file and other global env
     global ENDPOINTS, PROJECT_NAME, TARGET_NAMES
     ENDPOINTS = [
-        f"/gordo/v0/{project_name}/{sanitized_name}/healthcheck"
-        for sanitized_name in target_names_sanitized
+        f"/gordo/v0/{project_name}/{target_name}/healthcheck"
+        for target_name in target_names
     ]
     PROJECT_NAME = project_name
     TARGET_NAMES = target_names
@@ -89,13 +85,8 @@ def build_app(
 
 
 def run_server(
-    host: str,
-    port: int,
-    debug: bool,
-    project_name: str,
-    target_names: Iterable[str],
-    target_names_sanitized: Iterable[str],
+    host: str, port: int, debug: bool, project_name: str, target_names: Iterable[str]
 ):
 
-    app = build_app(project_name, target_names, target_names_sanitized)
+    app = build_app(project_name, target_names)
     app.run(host, port, debug=debug)

--- a/tests/test_watchman.py
+++ b/tests/test_watchman.py
@@ -9,13 +9,9 @@ from gordo_components.watchman import server
 
 
 TARGET_NAMES = ["CT-machine-name-456", "CT-machine-name-123"]
-TARGET_NAMES_SANITIZED = [
-    "ct-machine-name-456-kn209d",
-    "ct-machine-name-123-ksno0s9f092",
-]
 PROJECT_NAME = "some-project-name"
 AMBASSADORHOST = "ambassador"
-URL_FORMAT = "http://{host}/gordo/v0/{project_name}/{sanitized_name}/healthcheck"
+URL_FORMAT = "http://{host}/gordo/v0/{project_name}/{target_name}/healthcheck"
 
 
 def request_callback(_request):
@@ -30,11 +26,7 @@ def request_callback(_request):
 
 class WatchmanTestCase(unittest.TestCase):
     def setUp(self):
-        app = server.build_app(
-            project_name=PROJECT_NAME,
-            target_names=TARGET_NAMES,
-            target_names_sanitized=TARGET_NAMES_SANITIZED,
-        )
+        app = server.build_app(project_name=PROJECT_NAME, target_names=TARGET_NAMES)
         app.testing = True
         self.app = app.test_client()
 
@@ -64,11 +56,9 @@ class WatchmanTestCase(unittest.TestCase):
         # List of expected endpoints given the current CONFIG_FILE and the project name
         expected_endpoints = [
             URL_FORMAT.format(
-                host=AMBASSADORHOST,
-                project_name=PROJECT_NAME,
-                sanitized_name=sanitized_name,
+                host=AMBASSADORHOST, project_name=PROJECT_NAME, target_name=target_name
             )
-            for sanitized_name in TARGET_NAMES_SANITIZED
+            for target_name in TARGET_NAMES
         ]
 
         data = resp.get_json()


### PR DESCRIPTION
Depends on https://github.com/equinor/gordo-infrastructure/pull/161

Infrastructure is updated to only allow URL safe names for machines by default, this removes Watchman's dependency on getting sanitized target names.