### PR TITLE
Add dataset/pandas filter_rows

### DIFF
--- a/gordo_components/dataset/datasets.py
+++ b/gordo_components/dataset/datasets.py
@@ -1,12 +1,15 @@
 # -*- coding: utf-8 -*-
 
 import logging
+from typing import Tuple, List
+
 import numpy as np
 import pandas as pd
 from datetime import datetime
 
 from gordo_components.dataset.base import GordoBaseDataset
 from gordo_components.data_provider.base import GordoBaseDataProvider
+from gordo_components.dataset.filter_rows import pandas_filter_rows
 
 logger = logging.getLogger(__name__)
 
@@ -17,15 +20,41 @@ class TimeSeriesDataset(GordoBaseDataset):
         data_provider: GordoBaseDataProvider,
         from_ts: datetime,
         to_ts: datetime,
-        tag_list: list,
+        tag_list: List[str],
         resolution: str = "10T",
+        row_filter: str = "",
         **_kwargs,
     ):
+        """
+        Creates a TimeSeriesDataset backed by a provided dataprovider.
+
+        A TimeSeriesDataset is a dataset backed by timeseries, but resampled,
+        aligned, and (optionally) filtered.
+
+        Parameters
+        ----------
+        data_provider: GordoBaseDataProvider
+            A dataprovider which can provide dataframes for tags from from_ts to to_ts
+        from_ts: datetime
+            Earliest possible point in the dataset (inclusive)
+        to_ts: datetime
+            Earliest possible point in the dataset (exclusive)
+        tag_list: List[Str]
+            List of tags to include in the dataset
+        resolution: str
+            The bucket size for grouping all incoming time data (e.g. "10T").
+        row_filter: str
+            Filter on the rows. Only rows satisfying the filter will be in the dataset.
+            See :func:`gordo_components.dataset.filter_rows.pandas_filter_rows` for
+            further documentation of the filter format.
+        _kwargs
+        """
         self.from_ts = from_ts
         self.to_ts = to_ts
         self.tag_list = tag_list
         self.resolution = resolution
         self.data_provider = data_provider
+        self.row_filter = row_filter
 
         if not self.from_ts.tzinfo or not self.to_ts.tzinfo:
             raise ValueError(
@@ -33,12 +62,14 @@ class TimeSeriesDataset(GordoBaseDataset):
                 f"information"
             )
 
-    def get_data(self) -> pd.DataFrame:
+    def get_data(self) -> Tuple[pd.DataFrame, None]:
         dataframes = self.data_provider.load_dataframes(
             from_ts=self.from_ts, to_ts=self.to_ts, tag_list=self.tag_list
         )
         X = self.join_timeseries(dataframes, self.from_ts, self.resolution)
         y = None
+        if self.row_filter:
+            X = pandas_filter_rows(X, self.row_filter)
         return X, y
 
     def get_metadata(self):
@@ -47,6 +78,7 @@ class TimeSeriesDataset(GordoBaseDataset):
             "train_start_date": self.from_ts,
             "train_end_date": self.to_ts,
             "resolution": self.resolution,
+            "filter": self.row_filter,
         }
         return metadata
 

--- a/gordo_components/dataset/datasets.py
+++ b/gordo_components/dataset/datasets.py
@@ -3,10 +3,10 @@
 import logging
 from typing import Tuple, List
 
-import numpy as np
 import pandas as pd
 from datetime import datetime
 
+from gordo_components.data_provider.providers import RandomDataProvider
 from gordo_components.dataset.base import GordoBaseDataset
 from gordo_components.data_provider.base import GordoBaseDataProvider
 from gordo_components.dataset.filter_rows import pandas_filter_rows
@@ -83,22 +83,18 @@ class TimeSeriesDataset(GordoBaseDataset):
         return metadata
 
 
-class RandomDataset(GordoBaseDataset):
+class RandomDataset(TimeSeriesDataset):
     """
-    Get a GordoBaseDataset which returns random values for X and y
+    Get a TimeSeriesDataset backed by
+    gordo_components.data_provider.providers.RandomDataProvider
     """
 
-    def __init__(self, size=100, n_features=20, **kwargs):
-        self.size = size
-        self.n_features = n_features
-
-    def get_data(self):
-        """return X and y data"""
-        X = np.random.random(size=self.size * self.n_features).reshape(
-            -1, self.n_features
+    def __init__(self, from_ts: datetime, to_ts: datetime, tag_list: list, **kwargs):
+        kwargs.pop("data_provider", None)  # Dont care what you ask for, you get random!
+        super().__init__(
+            data_provider=RandomDataProvider(),
+            from_ts=from_ts,
+            to_ts=to_ts,
+            tag_list=tag_list,
+            **kwargs,
         )
-        return X, X.copy()
-
-    def get_metadata(self):
-        metadata = {"size": self.size, "n_features": self.n_features}
-        return metadata

--- a/gordo_components/dataset/filter_rows.py
+++ b/gordo_components/dataset/filter_rows.py
@@ -41,21 +41,24 @@ class _DfNameInserter(ast.NodeTransformer):
         )
 
 
-def filter_rows(df, filt):
+def pandas_filter_rows(df, filter_str: str):
     """
 
     Parameters
     ----------
     df: pandas.Dataframe
-        Dataframe to filter rows from. Does not modify the parameter
-    filt: str
-          String representing the filter. Can be a boolean combination of conditions,
-          where conditions are comparisons of column names and either other columns
-          or numeric values. The rows matching the filter are kept.
+      Dataframe to filter rows from. Does not modify the parameter
+    filter_str: str
+      String representing the filter. Can be a boolean combination of conditions,
+      where conditions are comparisons of column names and either other columns
+      or numeric values. The rows matching the filter are kept. Column names must be
+      quoted in single strings. Example of a legal filter is " 'Tag A' > 5 "
+
 
     Returns
     -------
-    pandas.Dataframe The dataframe with any rows matching the filter removed
+    pandas.Dataframe
+        The dataframe containing only rows matching the filter
 
     Examples
     --------
@@ -73,17 +76,17 @@ def filter_rows(df, filt):
     6  2  0
     7  2  1
     8  2  2
-    >>> filter_rows(df, "'A'>1")
+    >>> pandas_filter_rows(df, "'A'>1")
        A  B
     6  2  0
     7  2  1
     8  2  2
-    >>> filter_rows(df, "'A'>'B'")
+    >>> pandas_filter_rows(df, "'A'>'B'")
        A  B
     3  1  0
     6  2  0
     7  2  1
-    >>> filter_rows(df, "('A'>1) | ('B'<1)")
+    >>> pandas_filter_rows(df, "('A'>1) | ('B'<1)")
        A  B
     0  0  0
     3  1  0
@@ -93,9 +96,9 @@ def filter_rows(df, filt):
 
     """
 
-    parsed_filter = ast.parse(filt, mode="eval")
+    parsed_filter = ast.parse(filter_str, mode="eval")
     if not _safe_ast(parsed_filter):
-        raise ValueError(f"Unsafe expression {filt}")
+        raise ValueError(f"Unsafe expression {filter_str}")
     # Replaces strings (assumed to represent column names) with df[..]. df_name _must_
     # match the parameter name of this function
     parsed_filter = _DfNameInserter(df_name="df").visit(parsed_filter)

--- a/gordo_components/dataset/filter_rows.py
+++ b/gordo_components/dataset/filter_rows.py
@@ -1,0 +1,151 @@
+import ast
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class _DfNameInserter(ast.NodeTransformer):
+    def __init__(self, df_name="df"):
+        """
+        Constructs a ast.NodeTransformer which inserts df[X] around strings X.
+
+        So if it is given
+        ast.parse("('A' > 2) | (('B' < 10) & ('C' > 123.31))")
+        it will return the same as
+        ast.parse("(df['A'] > 2) | ((df['B'] < 10) & (df['C'] > 123.31))")
+
+        Parameters
+        ----------
+        df_name : str
+                  Name of the string to insert "around" strings.
+
+        Examples
+        --------
+        >>> ast.dump(_DfNameInserter().visit(ast.parse("'A' > 2"))) == ast.dump(ast.parse("df['A'] > 2"))
+        True
+
+        """
+        self.df_name = df_name
+        super().__init__()
+
+    def visit_Str(self, node):
+        return ast.fix_missing_locations(
+            ast.copy_location(
+                ast.Subscript(
+                    value=ast.Name(id=self.df_name, ctx=ast.Load()),
+                    slice=ast.Index(value=ast.copy_location(ast.Str(s=node.s), node)),
+                    ctx=ast.Load(),
+                ),
+                node,
+            )
+        )
+
+
+def filter_rows(df, filt):
+    """
+
+    Parameters
+    ----------
+    df: pandas.Dataframe
+        Dataframe to filter rows from. Does not modify the parameter
+    filt: str
+          String representing the filter. Can be a boolean combination of conditions,
+          where conditions are comparisons of column names and either other columns
+          or numeric values. The rows matching the filter are kept.
+
+    Returns
+    -------
+    pandas.Dataframe The dataframe with any rows matching the filter removed
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import pandas as pd
+    >>> df = pd.DataFrame(list(np.ndindex((3,3))), columns=list('AB'))
+    >>> df
+       A  B
+    0  0  0
+    1  0  1
+    2  0  2
+    3  1  0
+    4  1  1
+    5  1  2
+    6  2  0
+    7  2  1
+    8  2  2
+    >>> filter_rows(df, "'A'>1")
+       A  B
+    6  2  0
+    7  2  1
+    8  2  2
+    >>> filter_rows(df, "'A'>'B'")
+       A  B
+    3  1  0
+    6  2  0
+    7  2  1
+    >>> filter_rows(df, "('A'>1) | ('B'<1)")
+       A  B
+    0  0  0
+    3  1  0
+    6  2  0
+    7  2  1
+    8  2  2
+
+    """
+
+    parsed_filter = ast.parse(filt, mode="eval")
+    if not _safe_ast(parsed_filter):
+        raise ValueError(f"Unsafe expression {filt}")
+    # Replaces strings (assumed to represent column names) with df[..]. df_name _must_
+    # match the parameter name of this function
+    parsed_filter = _DfNameInserter(df_name="df").visit(parsed_filter)
+    # The eval requires the dataframe to be called 'df'
+    pandas_filter = eval(compile(parsed_filter, filename=__name__, mode="eval"))
+    return df[pandas_filter]
+
+
+# Contains all the legal AST nodes. The parsed expression below contains all components
+# allowed in a filter query.
+_LEGAL_AST_NODES = {
+    type(a)
+    for a in ast.walk(  # type: ignore
+        ast.parse(
+            "('A'<6) | ('B' <= 2) & ('C' == 4.3) | ('A'>-0.1 ) | ~('A'>= (1-2)) "
+            "| ('A' < ('B'+1)) | ('A' < ('B'*1)) | ('A' < ('B'-1)) | ('A' < ('B'/2)) "
+            "| ('A' < ('B' **2))",
+            mode="eval",
+        ).body
+    )
+}
+
+
+def _safe_ast(some_ast):
+    """
+    Validates that the parameter AST only contain safe AST nodes, that is nodes which
+    are deemed to be safe to evaluate. Those are the nodes in _LEGAL_AST_NODES,
+    except that the top-level node is allowed to be _ast.Expression,
+
+
+    Parameters
+    ----------
+    some_ast: a parsed
+
+    Examples
+    --------
+    >>> _safe_ast(ast.parse("('A'<6) | ('B' <= 2)", mode="eval"))
+    True
+    >>> _safe_ast(ast.parse("sys.exit(0)", mode="eval"))
+    False
+    """
+    logger.debug(f"Validating AST: {ast.dump(some_ast)}")
+    if type(some_ast) is ast.Expression:
+        some_ast = some_ast.body
+
+    current_ast_nodes = {type(a) for a in list(ast.walk(some_ast))}
+    is_subset = current_ast_nodes.issubset(_LEGAL_AST_NODES)
+    if not is_subset:
+        logger.debug(
+            f"Found that AST contained illegal nodes: "
+            f"{current_ast_nodes.difference(_LEGAL_AST_NODES)}"
+        )
+    return is_subset

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -2,6 +2,7 @@
 
 import unittest
 import os
+import dateutil
 from tempfile import TemporaryDirectory
 from gordo_components.builder.build_model import _save_model_for_workflow
 
@@ -24,7 +25,12 @@ class ModelBuilderTestCase(unittest.TestCase):
                     "kind": "feedforward_hourglass"
                 }
             }
-            data_config = {"type": "RandomDataset"}
+            data_config = {
+                "type": "RandomDataset",
+                "from_ts": dateutil.parser.isoparse("2017-12-25 06:00:00Z"),
+                "to_ts": dateutil.parser.isoparse("2017-12-30 06:00:00Z"),
+                "tag_list": ["Tag 1", "Tag 2"],
+            }
             output_dir = os.path.join(tmpdir, "some", "sub", "directories")
 
             model, metadata = build_model(

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -10,7 +10,6 @@ from datetime import datetime
 
 from gordo_components.data_provider.base import GordoBaseDataProvider
 from gordo_components.dataset.datasets import RandomDataset, TimeSeriesDataset
-from gordo_components.dataset import _get_dataset
 from gordo_components.dataset.base import GordoBaseDataset
 
 
@@ -19,20 +18,21 @@ class DatasetTestCase(unittest.TestCase):
         """
         Test expected attributes
         """
-        config = {"type": "RandomDataset"}
 
-        dataset = _get_dataset(config)
+        start = dateutil.parser.isoparse("2017-12-25 06:00:00Z")
+        end = dateutil.parser.isoparse("2017-12-29 06:00:00Z")
+
+        dataset = RandomDataset(from_ts=start, to_ts=end, tag_list=["Tag 1", "Tag 2"])
 
         self.assertTrue(isinstance(dataset, GordoBaseDataset))
-        self.assertTrue(isinstance(dataset, RandomDataset))
         self.assertTrue(hasattr(dataset, "get_data"))
         self.assertTrue(hasattr(dataset, "get_metadata"))
 
         X, y = dataset.get_data()
-        self.assertTrue(isinstance(X, np.ndarray))
+        self.assertTrue(isinstance(X, pd.DataFrame))
 
         # y can either be None or an numpy array
-        self.assertTrue(isinstance(y, np.ndarray) or y is None)
+        self.assertTrue(isinstance(y, pd.DataFrame) or y is None)
 
         metadata = dataset.get_metadata()
         self.assertTrue(isinstance(metadata, dict))
@@ -176,6 +176,12 @@ class TimeSeriesDatasetTest(unittest.TestCase):
 
 
 class MockDataSource(GordoBaseDataProvider):
+    def __init__(self, **kwargs):
+        pass
+
+    def can_handle_tag(self, tag):
+        return True
+
     def load_dataframes(
         self, from_ts: datetime, to_ts: datetime, tag_list: List[str]
     ) -> Iterable[pd.DataFrame]:

--- a/tests/test_filter_rows.py
+++ b/tests/test_filter_rows.py
@@ -2,7 +2,7 @@ import unittest
 import numpy as np
 import pandas as pd
 from pandas.util.testing import assert_frame_equal
-from gordo_components.dataset.filter_rows import filter_rows
+from gordo_components.dataset.filter_rows import pandas_filter_rows
 
 
 class TestFilterRows(unittest.TestCase):
@@ -12,24 +12,24 @@ class TestFilterRows(unittest.TestCase):
 
     def test_filter_rows_basic(self):
         df = self.df
-        self.assertEqual(len(filter_rows(df, "'Tag  1' <= 'Tag 2'")), 3)
-        self.assertEqual(len(filter_rows(df, "'Tag  1' == 'Tag 2'")), 2)
+        self.assertEqual(len(pandas_filter_rows(df, "'Tag  1' <= 'Tag 2'")), 3)
+        self.assertEqual(len(pandas_filter_rows(df, "'Tag  1' == 'Tag 2'")), 2)
         self.assertEqual(
-            len(filter_rows(df, "('Tag  1' <= 'Tag 2') | 'Tag 2' < 2 ")), 20
+            len(pandas_filter_rows(df, "('Tag  1' <= 'Tag 2') | 'Tag 2' < 2 ")), 20
         )
         self.assertEqual(
-            len(filter_rows(df, "('Tag  1' <= 'Tag 2') | 'Tag 2' < 0.9 ")), 9
+            len(pandas_filter_rows(df, "('Tag  1' <= 'Tag 2') | 'Tag 2' < 0.9 ")), 9
         )
 
         assert_frame_equal(
-            filter_rows(df, "('Tag  1' <= 'Tag 2')"),
-            filter_rows(df, "~('Tag  1' > 'Tag 2')"),
+            pandas_filter_rows(df, "('Tag  1' <= 'Tag 2')"),
+            pandas_filter_rows(df, "~('Tag  1' > 'Tag 2')"),
         )
 
     def test_filter_rows_catches_illegal(self):
         with self.assertRaises(ValueError):
-            filter_rows(self.df, "sys.exit(0)")
+            pandas_filter_rows(self.df, "sys.exit(0)")
         with self.assertRaises(ValueError):
-            filter_rows(self.df, "lambda x:x")
+            pandas_filter_rows(self.df, "lambda x:x")
         with self.assertRaises(ValueError):
-            filter_rows(self.df, "__import__('os').system('clear')"), ValueError
+            pandas_filter_rows(self.df, "__import__('os').system('clear')"), ValueError

--- a/tests/test_filter_rows.py
+++ b/tests/test_filter_rows.py
@@ -1,0 +1,35 @@
+import unittest
+import numpy as np
+import pandas as pd
+from pandas.util.testing import assert_frame_equal
+from gordo_components.dataset.filter_rows import filter_rows
+
+
+class TestFilterRows(unittest.TestCase):
+    @classmethod
+    def setUp(self):
+        self.df = pd.DataFrame(list(np.ndindex((10, 2))), columns=["Tag  1", "Tag 2"])
+
+    def test_filter_rows_basic(self):
+        df = self.df
+        self.assertEqual(len(filter_rows(df, "'Tag  1' <= 'Tag 2'")), 3)
+        self.assertEqual(len(filter_rows(df, "'Tag  1' == 'Tag 2'")), 2)
+        self.assertEqual(
+            len(filter_rows(df, "('Tag  1' <= 'Tag 2') | 'Tag 2' < 2 ")), 20
+        )
+        self.assertEqual(
+            len(filter_rows(df, "('Tag  1' <= 'Tag 2') | 'Tag 2' < 0.9 ")), 9
+        )
+
+        assert_frame_equal(
+            filter_rows(df, "('Tag  1' <= 'Tag 2')"),
+            filter_rows(df, "~('Tag  1' > 'Tag 2')"),
+        )
+
+    def test_filter_rows_catches_illegal(self):
+        with self.assertRaises(ValueError):
+            filter_rows(self.df, "sys.exit(0)")
+        with self.assertRaises(ValueError):
+            filter_rows(self.df, "lambda x:x")
+        with self.assertRaises(ValueError):
+            filter_rows(self.df, "__import__('os').system('clear')"), ValueError


### PR DESCRIPTION
The function filter_rows accepts a dataframe and an filter expression,
and returns the dataframe but only containing the rows which satisfy the
filter expression. The expression is a boolean combination of
comparisons between column names or numbers.

This closes equinor/gordo-infrastructure#146

I ended up also creating a RandomDataProvider since I though I would use it for testing, but I ended up just mocking a dataprovider. I can remove it, or keep it. 