### PR TITLE
 Add requirement numexpr as recommended by pandas 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,6 +31,7 @@ keras-preprocessing==1.0.5  # via keras, tensorflow
 keras==2.2.4
 markdown==3.0.1           # via tensorboard
 markupsafe==1.1.0         # via jinja2
+numexpr==2.6.9
 numpy==1.16.0
 pandas==0.23.4
 pip-tools==3.2.0

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ install_requires = [
     "Keras~=2.2",
     "numpy~=1.15",
     "pandas~=0.23",
+    "numexpr>=2.6.1",
     "pip-tools~=3.1",
     "python-dateutil~=2.7",
     "pyyaml>=4.2b1",


### PR DESCRIPTION
Recommended but not required by pandas.
https://pandas.pydata.org/pandas-docs/stable/install.html#install-recommended-dependencies

I tried bottleneck as well, but it needs gcc, so I dropped it for now.

Maybe silly to add without benchmarking(?), but I guess we think the Pandas people know what they are doing when they recommend installing them?

This closes #118 