### PR TITLE
Update cli.build to reference data config keys and not env vars

### DIFF
--- a/gordo_components/cli.py
+++ b/gordo_components/cli.py
@@ -69,13 +69,15 @@ def build(output_dir, model_config, data_config, metadata):
     # TODO: Move all data related input from environment variable to data_config,
     # TODO: thereby removing all these data_config['variable'] lines
 
-    data_config["tag_list"] = literal_eval(os.environ.get("TAGS", "[]"))
+    data_config["tag_list"] = data_config.pop("tags")
 
     # TODO: Move parsing from here, into the InfluxDataSet class
-    data_config["from_ts"] = dateutil.parser.isoparse(os.environ["TRAIN_START_DATE"])
+    data_config["from_ts"] = dateutil.parser.isoparse(
+        data_config.pop("train_start_date")
+    )
 
     # TODO: Move parsing from here, into the InfluxDataSet class
-    data_config["to_ts"] = dateutil.parser.isoparse(os.environ["TRAIN_END_DATE"])
+    data_config["to_ts"] = dateutil.parser.isoparse(data_config.pop("train_end_date"))
 
     logger.info(f"Building, output will be at: {output_dir}")
     logger.info(f"Model config: {model_config}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,9 +41,8 @@ class CliTestCase(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             with temp_env_vars(
                 OUTPUT_DIR=tmpdir,
-                TRAIN_START_DATE="2015-01-01",
-                TRAIN_END_DATE="2015-06-01",
-                DATA_CONFIG='{"type": "RandomDataset"}',
+                DATA_CONFIG='{"type": "RandomDataset", "train_start_date": "2015-01-01",'
+                ' "train_end_date": "2015-06-01", "tags": ["tag1", "tag2"]}',
                 MODEL_CONFIG=json.dumps(model_config),
             ):
                 result = self.runner.invoke(cli.gordo, ["build"])


### PR DESCRIPTION
Depends on https://github.com/equinor/gordo-infrastructure/pull/190

Part of setting up for #121 and #122 

train start/end and tags are now part of data_config from infrastructure workflow generation