### PR TITLE
Implement feedforward_hourglass model builder

### DIFF
--- a/examples/Gordo-Workflow-High-Level.ipynb
+++ b/examples/Gordo-Workflow-High-Level.ipynb
@@ -71,7 +71,7 @@
     "    steps:\n",
     "      - sklearn.preprocessing.data.MinMaxScaler\n",
     "      - gordo_components.model.models.KerasAutoEncoder:\n",
-    "          kind: feedforward_symetric\n",
+    "          kind: feedforward_model\n",
     "\"\"\""
    ]
   },

--- a/examples/Gordo-Workflow-High-Level.ipynb
+++ b/examples/Gordo-Workflow-High-Level.ipynb
@@ -71,7 +71,7 @@
     "    steps:\n",
     "      - sklearn.preprocessing.data.MinMaxScaler\n",
     "      - gordo_components.model.models.KerasAutoEncoder:\n",
-    "          kind: feedforward_model\n",
+    "          kind: feedforward_hourglass\n",
     "\"\"\""
    ]
   },

--- a/examples/Gordo-Workflow-Semi-Low-Level.ipynb
+++ b/examples/Gordo-Workflow-Semi-Low-Level.ipynb
@@ -180,7 +180,7 @@
     "        steps:\n",
     "          - sklearn.preprocessing.data.MinMaxScaler\n",
     "          - gordo_components.model.models.KerasAutoEncoder:\n",
-    "              kind: feedforward_model\n",
+    "              kind: feedforward_hourglass\n",
     "    \"\"\"\n",
     ")\n",
     "pipe = serializer.pipeline_from_definition(config)\n",

--- a/examples/Gordo-Workflow-Semi-Low-Level.ipynb
+++ b/examples/Gordo-Workflow-Semi-Low-Level.ipynb
@@ -180,7 +180,7 @@
     "        steps:\n",
     "          - sklearn.preprocessing.data.MinMaxScaler\n",
     "          - gordo_components.model.models.KerasAutoEncoder:\n",
-    "              kind: feedforward_symetric\n",
+    "              kind: feedforward_model\n",
     "    \"\"\"\n",
     ")\n",
     "pipe = serializer.pipeline_from_definition(config)\n",

--- a/gordo_components/builder/build_model.py
+++ b/gordo_components/builder/build_model.py
@@ -25,7 +25,7 @@ def build_model(model_config: dict, data_config: dict, metadata: dict):
         model_config: dict - mapping of Model to initialize and any additional
                              kwargs which are to be used in it's initialization
                              Example: {'type': 'KerasAutoEncoder',
-                                       'kind': 'feedforward_model'}
+                                       'kind': 'feedforward_hourglass'}
         data_config: dict - mapping of the Dataset to initialize, following the
                             same logic as model_config
         metadata: dict - mapping of arbitrary metadata data

--- a/gordo_components/builder/build_model.py
+++ b/gordo_components/builder/build_model.py
@@ -25,7 +25,7 @@ def build_model(model_config: dict, data_config: dict, metadata: dict):
         model_config: dict - mapping of Model to initialize and any additional
                              kwargs which are to be used in it's initialization
                              Example: {'type': 'KerasAutoEncoder',
-                                       'kind': 'feedforward_symetric'}
+                                       'kind': 'feedforward_model'}
         data_config: dict - mapping of the Dataset to initialize, following the
                             same logic as model_config
         metadata: dict - mapping of arbitrary metadata data

--- a/gordo_components/cli.py
+++ b/gordo_components/cli.py
@@ -35,7 +35,9 @@ def gordo():
     pass
 
 
-DEFAULT_MODEL_CONFIG = "{'gordo_components.model.models.KerasAutoEncoder': {'kind': 'feedforward_symetric'}}"
+DEFAULT_MODEL_CONFIG = (
+    "{'gordo_components.model.models.KerasAutoEncoder': {'kind': 'feedforward_model'}}"
+)
 
 
 @click.command()

--- a/gordo_components/cli.py
+++ b/gordo_components/cli.py
@@ -36,7 +36,8 @@ def gordo():
 
 
 DEFAULT_MODEL_CONFIG = (
-    "{'gordo_components.model.models.KerasAutoEncoder': {'kind': 'feedforward_model'}}"
+    "{'gordo_components.model.models.KerasAutoEncoder': {'kind': "
+    "'feedforward_hourglass'}} "
 )
 
 

--- a/gordo_components/model/factories/feedforward_autoencoder.py
+++ b/gordo_components/model/factories/feedforward_autoencoder.py
@@ -4,6 +4,7 @@ from typing import List
 
 from keras import regularizers
 from keras.layers import Dense
+import keras
 from keras.models import Sequential as KerasSequential
 
 from gordo_components.model.register import register_model_builder
@@ -11,14 +12,14 @@ from gordo_components.model.register import register_model_builder
 
 @register_model_builder(type="KerasAutoEncoder")
 @register_model_builder(type="KerasBaseEstimator")
-def feedforward_symetric(
+def feedforward_model(
     n_features: int,
     enc_dim: List[int] = None,
     dec_dim: List[int] = None,
     enc_func: List[str] = None,
     dec_func: List[str] = None,
     **kwargs,
-):
+) -> keras.models.Sequential:
     """
     Builds a customized keras neural network auto-encoder based on a config dict
     Args:

--- a/gordo_components/model/factories/feedforward_autoencoder.py
+++ b/gordo_components/model/factories/feedforward_autoencoder.py
@@ -70,3 +70,32 @@ def feedforward_model(
 
     model.compile(optimizer="adam", loss="mean_squared_error", metrics=["accuracy"])
     return model
+
+
+@register_model_builder(type="KerasAutoEncoder")
+@register_model_builder(type="KerasBaseEstimator")
+def feedforward_symmetric(
+    n_features: int, dims: List[int], funcs: List[str], **kwargs
+) -> keras.models.Sequential:
+    """
+    Builds a symmetrical feedforward model
+
+    Parameters:
+    ----------
+        n_features: int
+                    Number of input and output neurons
+        dim: List[int]
+             Number of neurons per layers for the encoder, reversed for the decoder.
+             Must have len > 0
+        funcs: List[str]
+            Activation functions for the internal layers
+
+    Returns:
+    -------
+    keras.models.Sequential
+
+    """
+    if len(dims) == 0:
+        raise ValueError("Parameter dims must have len > 0")
+    return feedforward_model(n_features, dims, dims[::-1], funcs, funcs[::-1], **kwargs)
+

--- a/gordo_components/model/register.py
+++ b/gordo_components/model/register.py
@@ -2,6 +2,7 @@ import logging
 import inspect
 from typing import Dict, Callable, Any  # pragma: no flakes
 from gordo_components.model.models import GordoBase
+import keras
 
 logger = logging.getLogger(__name__)
 
@@ -41,12 +42,12 @@ class register_model_builder:
     }
     """
 
-    factories = dict()  # type: Dict[str, Dict[str, Callable[[int, Any], GordoBase]]]
+    factories = dict()  # type: Dict[str, Dict[str, Callable[..., keras.models.Model]]]
 
     def __init__(self, type: str):
         self.type = type
 
-    def __call__(self, build_fn: Callable[[int, Any], GordoBase]):
+    def __call__(self, build_fn: Callable[..., keras.models.Model]):
         self._register(self.type, build_fn)
         return build_fn
 

--- a/gordo_components/serializer/serializer.py
+++ b/gordo_components/serializer/serializer.py
@@ -241,7 +241,7 @@ def dump(obj: object, dest_dir: str, metadata: dict = None):
     ...     # PCA is picklable
     ...     ('pca', PCA(3)),
     ...     # KerasAutoEncoder implements both `save_to_dir` and `load_from_dir`
-    ...     ('model', KerasAutoEncoder(kind='feedforward_model'))])
+    ...     ('model', KerasAutoEncoder(kind='feedforward_hourglass'))])
     >>> with TemporaryDirectory() as tmp:
     ...     serializer.dump(obj=pipe, dest_dir=tmp)
     ...     pipe_clone = serializer.load(source_dir=tmp)

--- a/gordo_components/serializer/serializer.py
+++ b/gordo_components/serializer/serializer.py
@@ -35,7 +35,7 @@ def dumps(model: GordoBase) -> bytes:
 
     >>> from gordo_components.model.models import KerasAutoEncoder
     >>> from gordo_components import serializer
-    >>> model = KerasAutoEncoder('feedforward_model')
+    >>> model = KerasAutoEncoder('feedforward_symmetric')
     >>> serialized = serializer.dumps(model)
     >>> assert isinstance(serialized, bytes)
     >>> model_clone = serializer.loads(serialized)

--- a/gordo_components/serializer/serializer.py
+++ b/gordo_components/serializer/serializer.py
@@ -35,7 +35,7 @@ def dumps(model: GordoBase) -> bytes:
 
     >>> from gordo_components.model.models import KerasAutoEncoder
     >>> from gordo_components import serializer
-    >>> model = KerasAutoEncoder('feedforward_symetric')
+    >>> model = KerasAutoEncoder('feedforward_model')
     >>> serialized = serializer.dumps(model)
     >>> assert isinstance(serialized, bytes)
     >>> model_clone = serializer.loads(serialized)
@@ -241,8 +241,7 @@ def dump(obj: object, dest_dir: str, metadata: dict = None):
     ...     # PCA is picklable
     ...     ('pca', PCA(3)),
     ...     # KerasAutoEncoder implements both `save_to_dir` and `load_from_dir`
-    ...     ('model', KerasAutoEncoder(kind='feedforward_symetric'))
-    ... ])
+    ...     ('model', KerasAutoEncoder(kind='feedforward_model'))])
     >>> with TemporaryDirectory() as tmp:
     ...     serializer.dump(obj=pipe, dest_dir=tmp)
     ...     pipe_clone = serializer.load(source_dir=tmp)

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -21,7 +21,7 @@ class ModelBuilderTestCase(unittest.TestCase):
 
             model_config = {
                 "gordo_components.model.models.KerasAutoEncoder": {
-                    "kind": "feedforward_symetric"
+                    "kind": "feedforward_model"
                 }
             }
             data_config = {"type": "RandomDataset"}

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -21,7 +21,7 @@ class ModelBuilderTestCase(unittest.TestCase):
 
             model_config = {
                 "gordo_components.model.models.KerasAutoEncoder": {
-                    "kind": "feedforward_model"
+                    "kind": "feedforward_hourglass"
                 }
             }
             data_config = {"type": "RandomDataset"}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -32,7 +32,7 @@ class CliTestCase(unittest.TestCase):
 
         model_config = {
             "gordo_components.model.models.KerasAutoEncoder": {
-                "kind": "feedforward_symetric"
+                "kind": "feedforward_model"
             }
         }
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -32,7 +32,7 @@ class CliTestCase(unittest.TestCase):
 
         model_config = {
             "gordo_components.model.models.KerasAutoEncoder": {
-                "kind": "feedforward_model"
+                "kind": "feedforward_hourglass"
             }
         }
 

--- a/tests/test_feedforward_autoencoder.py
+++ b/tests/test_feedforward_autoencoder.py
@@ -5,6 +5,7 @@ from unittest import mock
 
 from gordo_components.model.factories.feedforward_autoencoder import (
     feedforward_symmetric,
+    feedforward_hourglass,
 )
 
 
@@ -36,3 +37,82 @@ class FeedForwardAutoEncoderTestCase(unittest.TestCase):
         """
         with self.assertRaises(ValueError):
             feedforward_symmetric(4, [], [])
+
+    @mock.patch(
+        "gordo_components.model.factories.feedforward_autoencoder.feedforward_model",
+        side_effect=feedforward_model_mocker,
+    )
+    def test_feedforward_hourglass_basic(self, _):
+        """
+        Test that feedforward_hourglass calls feedforward_model correctly
+        """
+        n_features, enc_dim, dec_dim, enc_func, dec_func = feedforward_hourglass(10)
+        self.assertEqual(n_features, 10)
+        self.assertEqual(enc_dim, [8, 7, 5])
+        self.assertEqual(dec_dim, [5, 7, 8])
+        self.assertEqual(enc_func, ["relu", "relu", "relu"])
+        self.assertEqual(dec_func, ["relu", "relu", "relu"])
+
+        n_features, enc_dim, dec_dim, enc_func, dec_func = feedforward_hourglass(
+            3, func="tanh"
+        )
+        self.assertEqual(n_features, 3)
+        self.assertEqual(enc_dim, [3, 2, 2])
+        self.assertEqual(dec_dim, [2, 2, 3])
+        self.assertEqual(enc_func, ["tanh", "tanh", "tanh"])
+        self.assertEqual(dec_func, ["tanh", "tanh", "tanh"])
+
+        n_features, enc_dim, dec_dim, enc_func, dec_func = feedforward_hourglass(
+            10, compression_factor=0.3
+        )
+        self.assertEqual(n_features, 10)
+        self.assertEqual(enc_dim, [8, 5, 3])
+        self.assertEqual(dec_dim, [3, 5, 8])
+        self.assertEqual(enc_func, ["relu", "relu", "relu"])
+        self.assertEqual(dec_func, ["relu", "relu", "relu"])
+
+    @mock.patch(
+        "gordo_components.model.factories.feedforward_autoencoder.feedforward_model",
+        side_effect=feedforward_model_mocker,
+    )
+    def test_feedforward_hourglass_compression_factors(self, _):
+        """
+        Test that feedforward_symmetric handles compression_factor=1 and
+        compression_factor=0 correctly.
+        """
+
+        # compression_factor=1 is no compression
+        n_features, enc_dim, dec_dim, enc_func, dec_func = feedforward_hourglass(
+            10, compression_factor=1
+        )
+        self.assertEqual(n_features, 10)
+        self.assertEqual(enc_dim, [10, 10, 10])
+        self.assertEqual(dec_dim, [10, 10, 10])
+        self.assertEqual(enc_func, ["relu", "relu", "relu"])
+        self.assertEqual(dec_func, ["relu", "relu", "relu"])
+
+        # compression_factor=0 has smallest layer with 1 node.
+        n_features, enc_dim, dec_dim, enc_func, dec_func = feedforward_hourglass(
+            100000, compression_factor=0
+        )
+        self.assertEqual(n_features, 100000)
+        self.assertEqual(enc_dim, [66667, 33334, 1])
+        self.assertEqual(dec_dim, [1, 33334, 66667])
+        self.assertEqual(enc_func, ["relu", "relu", "relu"])
+        self.assertEqual(dec_func, ["relu", "relu", "relu"])
+
+    def test_feedforward_hourglass_checks_enc_layers(self):
+        """
+        Test that feedforward_symmetric validates parameter requirements
+        """
+        with self.assertRaises(ValueError):
+            feedforward_hourglass(3, encoding_layers=0)
+
+    def test_feedforward_hourglass_checks_compression_factor(self):
+        """
+        Test that feedforward_symmetric validates parameter requirements
+        """
+        with self.assertRaises(ValueError):
+            feedforward_hourglass(3, compression_factor=2)
+        with self.assertRaises(ValueError):
+            feedforward_hourglass(3, compression_factor=-1)

--- a/tests/test_feedforward_autoencoder.py
+++ b/tests/test_feedforward_autoencoder.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+
+import unittest
+from unittest import mock
+
+from gordo_components.model.factories.feedforward_autoencoder import (
+    feedforward_symmetric,
+)
+
+
+def feedforward_model_mocker(n_features: int, enc_dim, dec_dim, enc_func, dec_func):
+    return n_features, enc_dim, dec_dim, enc_func, dec_func
+
+
+class FeedForwardAutoEncoderTestCase(unittest.TestCase):
+    @mock.patch(
+        "gordo_components.model.factories.feedforward_autoencoder.feedforward_model",
+        side_effect=feedforward_model_mocker,
+    )
+    def test_feedforward_symmetric_basic(self, _):
+        """
+        Test that feedforward_symmetric calls feedforward_model correctly
+        """
+        n_features, enc_dim, dec_dim, enc_func, dec_func = feedforward_symmetric(
+            5, [4, 3, 2, 1], ["relu", "relu", "tanh", "tanh"]
+        )
+        self.assertEqual(n_features, 5)
+        self.assertEqual(enc_dim, [4, 3, 2, 1])
+        self.assertEqual(dec_dim, [1, 2, 3, 4])
+        self.assertEqual(enc_func, ["relu", "relu", "tanh", "tanh"])
+        self.assertEqual(dec_func, ["tanh", "tanh", "relu", "relu"])
+
+    def test_feedforward_symmetric_checks_dims(self):
+        """
+        Test that feedforward_symmetric validates parameter requirements
+        """
+        with self.assertRaises(ValueError):
+            feedforward_symmetric(4, [], [])

--- a/tests/test_gordo_server.py
+++ b/tests/test_gordo_server.py
@@ -32,7 +32,7 @@ class GordoServerTestCase(unittest.TestCase):
                 steps:
                     - sklearn.preprocessing.data.MinMaxScaler
                     - gordo_components.model.models.KerasAutoEncoder:
-                        kind: feedforward_model
+                        kind: feedforward_hourglass
                 memory:
             """,
             Loader=ruamel.yaml.Loader,

--- a/tests/test_gordo_server.py
+++ b/tests/test_gordo_server.py
@@ -32,7 +32,7 @@ class GordoServerTestCase(unittest.TestCase):
                 steps:
                     - sklearn.preprocessing.data.MinMaxScaler
                     - gordo_components.model.models.KerasAutoEncoder:
-                        kind: feedforward_symetric
+                        kind: feedforward_model
                 memory:
             """,
             Loader=ruamel.yaml.Loader,

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -19,7 +19,7 @@ class KerasModelTestCase(unittest.TestCase):
         """
         config = {
             "type": "KerasAutoEncoder",
-            "kind": "feedforward_symetric",
+            "kind": "feedforward_model",
             "n_features": 10,
             "enc_dim": [8, 4, 2],
             "dec_dim": [2, 4, 8],
@@ -36,7 +36,7 @@ class KerasModelTestCase(unittest.TestCase):
     def test_keras_autoencoder_type(self):
         config = {
             "type": "KerasAutoEncoder",
-            "kind": "feedforward_symetric",
+            "kind": "feedforward_model",
             "n_features": 10,
             "enc_dim": [8, 4, 2],
             "dec_dim": [2, 4, 8],
@@ -50,7 +50,7 @@ class KerasModelTestCase(unittest.TestCase):
     def test_save_load(self):
         config = {
             "type": "KerasBaseEstimator",
-            "kind": "feedforward_symetric",
+            "kind": "feedforward_model",
             "n_features": 10,
             "enc_dim": [8, 4, 2],
             "dec_dim": [2, 4, 8],

--- a/tests/test_serializer_from_definition.py
+++ b/tests/test_serializer_from_definition.py
@@ -64,7 +64,7 @@ class ConfigToScikitLearnPipeTestCase(unittest.TestCase):
                         n_jobs: 1
                         transformer_weights:
                     - gordo_components.model.models.KerasAutoEncoder:
-                        kind: feedforward_model
+                        kind: feedforward_hourglass
             """,
             # This has only some named parameters included
             """
@@ -85,7 +85,7 @@ class ConfigToScikitLearnPipeTestCase(unittest.TestCase):
                             - sklearn.decomposition.truncated_svd.TruncatedSVD:
                                 n_components: 2
                     - gordo_components.model.models.KerasAutoEncoder:
-                        kind: feedforward_model
+                        kind: feedforward_hourglass
             """,
             # Define pipeline memory with something other than None w/o metadata
             """
@@ -130,7 +130,7 @@ class ConfigToScikitLearnPipeTestCase(unittest.TestCase):
                     n_jobs: 1
                     transformer_weights:
                 - gordo_components.model.models.KerasAutoEncoder:
-                    kind: feedforward_model
+                    kind: feedforward_hourglass
             """,
         ]
 
@@ -193,4 +193,4 @@ class ConfigToScikitLearnPipeTestCase(unittest.TestCase):
         # STEP 4 TEST:  Finally, the last step should be a KerasModel
         step4 = pipe.steps[3][1]
         self.assertIsInstance(step4, KerasAutoEncoder)
-        self.assertTrue(step4.kind, "feedforward_model")
+        self.assertTrue(step4.kind, "feedforward_hourglass")

--- a/tests/test_serializer_from_definition.py
+++ b/tests/test_serializer_from_definition.py
@@ -64,7 +64,7 @@ class ConfigToScikitLearnPipeTestCase(unittest.TestCase):
                         n_jobs: 1
                         transformer_weights:
                     - gordo_components.model.models.KerasAutoEncoder:
-                        kind: feedforward_symetric
+                        kind: feedforward_model
             """,
             # This has only some named parameters included
             """
@@ -85,7 +85,7 @@ class ConfigToScikitLearnPipeTestCase(unittest.TestCase):
                             - sklearn.decomposition.truncated_svd.TruncatedSVD:
                                 n_components: 2
                     - gordo_components.model.models.KerasAutoEncoder:
-                        kind: feedforward_symetric
+                        kind: feedforward_model
             """,
             # Define pipeline memory with something other than None w/o metadata
             """
@@ -130,7 +130,7 @@ class ConfigToScikitLearnPipeTestCase(unittest.TestCase):
                     n_jobs: 1
                     transformer_weights:
                 - gordo_components.model.models.KerasAutoEncoder:
-                    kind: feedforward_symetric
+                    kind: feedforward_model
             """,
         ]
 
@@ -193,4 +193,4 @@ class ConfigToScikitLearnPipeTestCase(unittest.TestCase):
         # STEP 4 TEST:  Finally, the last step should be a KerasModel
         step4 = pipe.steps[3][1]
         self.assertIsInstance(step4, KerasAutoEncoder)
-        self.assertTrue(step4.kind, "feedforward_symetric")
+        self.assertTrue(step4.kind, "feedforward_model")

--- a/tests/test_serializer_into_definition.py
+++ b/tests/test_serializer_into_definition.py
@@ -43,7 +43,7 @@ class PipelineToConfigTestCase(unittest.TestCase):
                             ]
                         ),
                     ),
-                    ("ae", KerasAutoEncoder(kind="feedforward_symetric")),
+                    ("ae", KerasAutoEncoder(kind="feedforward_model")),
                 ]
             ),
             # MinMax initialized (wrongly) with a list
@@ -67,7 +67,7 @@ class PipelineToConfigTestCase(unittest.TestCase):
                             ]
                         ),
                     ),
-                    ("ae", KerasAutoEncoder(kind="feedforward_symetric")),
+                    ("ae", KerasAutoEncoder(kind="feedforward_model")),
                 ]
             ),
             # MinMax initialized with tuple
@@ -91,7 +91,7 @@ class PipelineToConfigTestCase(unittest.TestCase):
                             ]
                         ),
                     ),
-                    ("ae", KerasAutoEncoder(kind="feedforward_symetric")),
+                    ("ae", KerasAutoEncoder(kind="feedforward_model")),
                 ]
             ),
             # First pipeline without explicit steps param, other with.
@@ -115,7 +115,7 @@ class PipelineToConfigTestCase(unittest.TestCase):
                             ]
                         ),
                     ),
-                    ("ae", KerasAutoEncoder(kind="feedforward_symetric")),
+                    ("ae", KerasAutoEncoder(kind="feedforward_model")),
                 ]
             ),
         ]
@@ -161,7 +161,7 @@ class PipelineToConfigTestCase(unittest.TestCase):
                         n_jobs:
                         transformer_weights:
                     - gordo_components.model.models.KerasAutoEncoder:
-                        kind: feedforward_symetric
+                        kind: feedforward_model
                 memory:
             """.rstrip()
             .strip()
@@ -214,7 +214,7 @@ class PipelineToConfigTestCase(unittest.TestCase):
                     "step_2",
                     FunctionTransformer(func=multiply_by, kw_args={"factor": 1}),
                 ),
-                ("step_3", KerasAutoEncoder(kind="feedforward_symetric")),
+                ("step_3", KerasAutoEncoder(kind="feedforward_model")),
             ]
         )
 
@@ -269,7 +269,7 @@ class PipelineToConfigTestCase(unittest.TestCase):
                         n_jobs: 1
                         transformer_weights:
                     - gordo_components.model.models.KerasAutoEncoder:
-                        kind: feedforward_symetric
+                        kind: feedforward_model
                 memory:
             """
         definition = ruamel.yaml.load(definition, Loader=ruamel.yaml.Loader)

--- a/tests/test_serializer_into_definition.py
+++ b/tests/test_serializer_into_definition.py
@@ -43,7 +43,7 @@ class PipelineToConfigTestCase(unittest.TestCase):
                             ]
                         ),
                     ),
-                    ("ae", KerasAutoEncoder(kind="feedforward_model")),
+                    ("ae", KerasAutoEncoder(kind="feedforward_hourglass")),
                 ]
             ),
             # MinMax initialized (wrongly) with a list
@@ -67,7 +67,7 @@ class PipelineToConfigTestCase(unittest.TestCase):
                             ]
                         ),
                     ),
-                    ("ae", KerasAutoEncoder(kind="feedforward_model")),
+                    ("ae", KerasAutoEncoder(kind="feedforward_hourglass")),
                 ]
             ),
             # MinMax initialized with tuple
@@ -91,7 +91,7 @@ class PipelineToConfigTestCase(unittest.TestCase):
                             ]
                         ),
                     ),
-                    ("ae", KerasAutoEncoder(kind="feedforward_model")),
+                    ("ae", KerasAutoEncoder(kind="feedforward_hourglass")),
                 ]
             ),
             # First pipeline without explicit steps param, other with.
@@ -115,7 +115,7 @@ class PipelineToConfigTestCase(unittest.TestCase):
                             ]
                         ),
                     ),
-                    ("ae", KerasAutoEncoder(kind="feedforward_model")),
+                    ("ae", KerasAutoEncoder(kind="feedforward_hourglass")),
                 ]
             ),
         ]
@@ -161,7 +161,7 @@ class PipelineToConfigTestCase(unittest.TestCase):
                         n_jobs:
                         transformer_weights:
                     - gordo_components.model.models.KerasAutoEncoder:
-                        kind: feedforward_model
+                        kind: feedforward_hourglass
                 memory:
             """.rstrip()
             .strip()
@@ -214,7 +214,7 @@ class PipelineToConfigTestCase(unittest.TestCase):
                     "step_2",
                     FunctionTransformer(func=multiply_by, kw_args={"factor": 1}),
                 ),
-                ("step_3", KerasAutoEncoder(kind="feedforward_model")),
+                ("step_3", KerasAutoEncoder(kind="feedforward_hourglass")),
             ]
         )
 
@@ -269,7 +269,7 @@ class PipelineToConfigTestCase(unittest.TestCase):
                         n_jobs: 1
                         transformer_weights:
                     - gordo_components.model.models.KerasAutoEncoder:
-                        kind: feedforward_model
+                        kind: feedforward_hourglass
                 memory:
             """
         definition = ruamel.yaml.load(definition, Loader=ruamel.yaml.Loader)

--- a/tests/test_serializer_load_dump.py
+++ b/tests/test_serializer_load_dump.py
@@ -68,7 +68,7 @@ class PipelineSerializationTestCase(unittest.TestCase):
                         ]
                     ),
                 ),
-                ("ae", KerasAutoEncoder(kind="feedforward_symetric")),
+                ("ae", KerasAutoEncoder(kind="feedforward_model")),
             ]
         )
 
@@ -162,7 +162,7 @@ class PipelineSerializationTestCase(unittest.TestCase):
 
     def test_dump_load_keras_directly(self):
 
-        model = KerasAutoEncoder(kind="feedforward_symetric")
+        model = KerasAutoEncoder(kind="feedforward_model")
 
         X = np.random.random(size=100).reshape(10, 10)
         model.fit(X.copy(), X.copy())

--- a/tests/test_serializer_load_dump.py
+++ b/tests/test_serializer_load_dump.py
@@ -68,7 +68,7 @@ class PipelineSerializationTestCase(unittest.TestCase):
                         ]
                     ),
                 ),
-                ("ae", KerasAutoEncoder(kind="feedforward_model")),
+                ("ae", KerasAutoEncoder(kind="feedforward_hourglass")),
             ]
         )
 
@@ -162,7 +162,7 @@ class PipelineSerializationTestCase(unittest.TestCase):
 
     def test_dump_load_keras_directly(self):
 
-        model = KerasAutoEncoder(kind="feedforward_model")
+        model = KerasAutoEncoder(kind="feedforward_hourglass")
 
         X = np.random.random(size=100).reshape(10, 10)
         model.fit(X.copy(), X.copy())


### PR DESCRIPTION
- Renamed `feedforward_symetric` to `feedforward_model`, since it is not symmetric. 
- Added `feedforward_symmetric` which is correctly spelled, and actually symmetric. 
- Added `feedforward_hourglass` which constructs the hourglass model given `n_features`.
- Change the default kind from `feedforward_model` to `feedforward_hourglass`, and changed many examples. 

The rename will definitively break a bunch of yaml-files in infrastructure, too bad. Issue about that is posted as equinor/gordo-infrastructure#191

This closes #124 