### PR TITLE
Implement DataProvider and Dataset separation

### DIFF
--- a/examples/Gordo-Workflow-High-Level.ipynb
+++ b/examples/Gordo-Workflow-High-Level.ipynb
@@ -18,17 +18,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Using TensorFlow backend.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import tempfile\n",
     "import yaml\n",
@@ -36,7 +28,8 @@
     "from dateutil.parser import isoparse\n",
     "\n",
     "from gordo_components import serializer\n",
-    "from gordo_components.builder import build_model"
+    "from gordo_components.builder import build_model\n",
+    "from gordo_components.data_provider.providers import DataLakeProvider"
    ]
   },
   {
@@ -48,7 +41,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -57,12 +50,13 @@
     "machines:\n",
     "\n",
     "  - name: asgb-morvin\n",
-    "    tags: #list of tags\n",
-    "      - asgb.19ZT3950%2FY%2FPRIM\n",
-    "      - asgb.19PST3925%2FDispMeasOut%2FPRIM\n",
-    "      - asgb.19PT3905%2FY%2F5mMID\n",
-    "    train_start_date: 2014-07-01T00:10:00+00:00\n",
-    "    train_end_date: 2015-01-01T00:00:00+00:00\n",
+    "    dataset:\n",
+    "      tags: #list of tags\n",
+    "        - asgb.19ZT3950%2FY%2FPRIM\n",
+    "        - asgb.19PST3925%2FDispMeasOut%2FPRIM\n",
+    "        - asgb.19PT3905%2FY%2F5mMID\n",
+    "      train_start_date: 2014-07-01T00:10:00+00:00\n",
+    "      train_end_date: 2015-01-01T00:00:00+00:00\n",
     "    metadata:\n",
     "      my-special-metadata-attr: is awesome!\n",
     "\n",
@@ -87,7 +81,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -102,16 +96,11 @@
     "\n",
     "# TODO: This is the ugliest portion, as we normally use resources [`Machine`] found in `gordo-infrastructure`\n",
     "data_config  = {\n",
-    "    \"type\": \"DataLakeBackedDataset\",  # We want to use `DataLakeBackedDataset` for data acquisition\n",
-    "    \n",
-    "    # The remaining are used for the initialization of the given dataset class, ie. `DataLakeBackedDataset`\n",
-    "    \"datalake_config\": {\n",
-    "        \"storename\": \"dataplatformdlsprod\", \n",
-    "        \"interactive\": True\n",
-    "    },\n",
-    "    \"from_ts\": isoparse(machine_config['train_start_date']),\n",
-    "    \"to_ts\": isoparse(machine_config['train_end_date']),\n",
-    "    \"tag_list\": machine_config['tags'],\n",
+    "    \"type\": \"TimeSeriesDataset\",  # We want to use `DataLakeBackedDataset` for data acquisition\n",
+    "    \"from_ts\": isoparse(machine_config['dataset']['train_start_date']),\n",
+    "    \"to_ts\": isoparse(machine_config['dataset']['train_end_date']),\n",
+    "    \"tag_list\": machine_config['dataset']['tags'],\n",
+    "    \"data_provider\": DataLakeProvider(storename=\"dataplatformdlsprod\", interactive=True),\n",
     "}"
    ]
   },
@@ -155,7 +144,7 @@
      "data": {
       "text/plain": [
        "Pipeline(memory=None,\n",
-       "     steps=[('step_0', MinMaxScaler(copy=True, feature_range=(0, 1))), ('step_1', <gordo_components.model.models.KerasAutoEncoder object at 0x7ff4e79689b0>)])"
+       "     steps=[('step_0', MinMaxScaler(copy=True, feature_range=(0, 1))), ('step_1', <gordo_components.model.models.KerasAutoEncoder object at 0x7f7ac48ea908>)])"
       ]
      },
      "execution_count": 6,
@@ -186,18 +175,18 @@
       "dataset:\n",
       "  resolution: 10T\n",
       "  tag_list: [asgb.19ZT3950%2FY%2FPRIM, asgb.19PST3925%2FDispMeasOut%2FPRIM, asgb.19PT3905%2FY%2F5mMID]\n",
-      "  train_end_date: '2015-01-01 00:00:00+00:00'\n",
-      "  train_start_date: '2014-07-01 00:10:00+00:00'\n",
+      "  train_end_date: 2015-01-01 00:00:00+00:00\n",
+      "  train_start_date: 2014-07-01 00:10:00+00:00\n",
       "model:\n",
-      "  data_query_duration_sec: 21.22299885749817\n",
-      "  model_builder_version: 0.7.1.dev5+gcae4439.d20190214\n",
+      "  data_query_duration_sec: 21.27293300628662\n",
+      "  model_builder_version: 0.9.1.dev3+g9da7836.d20190225\n",
       "  model_config:\n",
       "    sklearn.pipeline.Pipeline:\n",
       "      steps:\n",
       "      - sklearn.preprocessing.data.MinMaxScaler\n",
       "      - gordo_components.model.models.KerasAutoEncoder: {kind: feedforward_symetric}\n",
-      "  model_creation_date: '2019-02-14 10:33:42.938829+01:00'\n",
-      "  model_training_duration_sec: 3.9275035858154297\n",
+      "  model_creation_date: '2019-02-25 12:21:38.595111+01:00'\n",
+      "  model_training_duration_sec: 3.5922129154205322\n",
       "user-defined: {my-special-metadata-attr: is awesome!}\n",
       "\n"
      ]

--- a/examples/Gordo-Workflow-Semi-Low-Level.ipynb
+++ b/examples/Gordo-Workflow-Semi-Low-Level.ipynb
@@ -16,36 +16,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Using TensorFlow backend.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import dateutil.parser\n",
     "import yaml\n",
     "\n",
     "from datetime import datetime\n",
     "\n",
-    "from gordo_components.dataset.datasets import DataLakeBackedDataset\n",
+    "from gordo_components.dataset.datasets import TimeSeriesDataset\n",
+    "from gordo_components.data_provider.providers import DataLakeProvider\n",
     "from gordo_components import serializer\n",
     "\n",
     "\n",
-    "dataset = DataLakeBackedDataset(\n",
-    "    datalake_config={\"storename\": \"dataplatformdlsprod\", \"interactive\": True},\n",
+    "# Parameters used by both DataLakeProvider and TimeSeriesDataset\n",
+    "kwargs = dict(\n",
     "    from_ts=dateutil.parser.isoparse('2014-07-01T00:10:00+00:00'),\n",
     "    to_ts=dateutil.parser.isoparse('2015-01-01T00:00:00+00:00'),\n",
     "    tag_list=[\n",
     "        'asgb.19ZT3950%2FY%2FPRIM',\n",
     "        'asgb.19PST3925%2FDispMeasOut%2FPRIM'\n",
     "    ],\n",
-    ")"
+    "    data_provider=DataLakeProvider(storename=\"dataplatformdlsprod\", interactive=True),\n",
+    ")\n",
+    "dataset = TimeSeriesDataset(**kwargs)"
    ]
   },
   {

--- a/gordo_components/builder/build_model.py
+++ b/gordo_components/builder/build_model.py
@@ -6,17 +6,20 @@ import logging
 import datetime
 import time
 
-from typing import Dict, Any
+from typing import Dict, Any, Union
 from sklearn.base import BaseEstimator
 
 from gordo_components import serializer, __version__
 from gordo_components.dataset import _get_dataset
+from gordo_components.dataset.base import GordoBaseDataset
 
 
 logger = logging.getLogger(__name__)
 
 
-def build_model(model_config: dict, data_config: dict, metadata: dict):
+def build_model(
+    model_config: dict, data_config: Union[GordoBaseDataset, dict], metadata: dict
+):
     """
     Build a model and serialize to a directory for later serving.
 
@@ -35,7 +38,12 @@ def build_model(model_config: dict, data_config: dict, metadata: dict):
     """
     # Get the dataset from config
     logger.debug(f"Initializing Dataset with config {data_config}")
-    dataset = _get_dataset(data_config)
+
+    dataset = (
+        data_config
+        if isinstance(data_config, GordoBaseDataset)
+        else _get_dataset(data_config)
+    )
 
     logger.debug("Fetching training data")
     start = time.time()

--- a/gordo_components/cli.py
+++ b/gordo_components/cli.py
@@ -13,6 +13,7 @@ import yaml
 import click
 from gordo_components.builder import build_model
 from gordo_components.builder.build_model import _save_model_for_workflow
+from gordo_components.data_provider.providers import DataLakeProvider
 from gordo_components.server import server
 from gordo_components import watchman
 
@@ -49,8 +50,7 @@ DEFAULT_MODEL_CONFIG = (
 @click.argument(
     "data-config",
     envvar="DATA_CONFIG",
-    default='{"type": "DataLakeBackedDataset", "datalake_config": {"storename": '
-    '"dataplatformdlsprod", "interactive": "True"}}',
+    default='{"type": "TimeSeriesDataset"}',
     type=literal_eval,
 )
 @click.option("--metadata", envvar="METADATA", default="{}", type=literal_eval)
@@ -81,6 +81,9 @@ def build(output_dir, model_config, data_config, metadata):
 
     # TODO: Move parsing from here, into the InfluxDataSet class
     data_config["to_ts"] = dateutil.parser.isoparse(data_config.pop("train_end_date"))
+
+    # Set default data provider for data config
+    data_config["data_provider"] = DataLakeProvider()
 
     logger.info(f"Building, output will be at: {output_dir}")
     logger.info(f"Model config: {model_config}")

--- a/gordo_components/data_provider/base.py
+++ b/gordo_components/data_provider/base.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+
+import abc
+
+from datetime import datetime
+from typing import Iterable, List
+
+import pandas as pd
+
+
+class GordoBaseDataProvider(abc.ABC):
+    @abc.abstractmethod
+    def load_dataframes(
+        self, from_ts: datetime, to_ts: datetime, tag_list: List[str]
+    ) -> Iterable[pd.DataFrame]:
+        """
+        Load the required data as an iterable of dataframes where each
+        is a single column dataframe with time index
+
+        Parameters
+        ----------
+        from_ts: datetime - Datetime object representing the start of fetching data
+        to_ts: datetime - Datetime object representing the end of fetching data
+        tag_list: List[str] - List of tags to fetch, where each will end up being its own dataframe
+
+        Returns
+        -------
+        Iterable[pd.DataFrame]
+        """
+        ...

--- a/gordo_components/data_provider/providers.py
+++ b/gordo_components/data_provider/providers.py
@@ -1,0 +1,287 @@
+# -*- coding: utf-8 -*-
+import os
+import re
+
+from datetime import datetime
+from typing import List, Iterable
+
+import numpy as np
+import pandas as pd
+from azure.datalake.store import core, lib
+from influxdb import DataFrameClient
+
+from gordo_components.data_provider.base import GordoBaseDataProvider
+from gordo_components.dataset.datasets import logger
+
+
+class DataLakeProvider(GordoBaseDataProvider):
+    TAG_TO_PATH = [
+        (
+            re.compile(r"^asgb."),
+            "/raw/corporate/PI System Operation North/sensordata/1191-ASGB",
+        ),
+        (
+            re.compile(r"^gra."),
+            "/raw/corporate/Aspen MS - IP21 Grane/sensordata/1755-GRA",
+        ),
+        (
+            re.compile(r"^1125."),
+            "/raw/corporate/PI System Operation Norway/sensordata/1125-KVB",
+        ),
+        (
+            re.compile(r"^trb."),
+            "/raw/corporate/Aspen MS - IP21 Troll B/sensordata/1775-TROB",
+        ),
+        (
+            re.compile(r"^trc."),
+            "/raw/corporate/Aspen MS - IP21 Troll C/sensordata/1776-TROC",
+        ),
+    ]
+
+    def __init__(
+        self,
+        storename: str = "dataplatformdlsprod",
+        interactive: bool = False,
+        dl_service_auth_str: str = None,
+    ):
+        """
+        Instantiates a DataLakeBackedDataset, for fetching of data from the data lake
+        Parameters
+        ----------
+        storename: str - The store name to read data from
+        interactive: bool - To perform authentication interactively, or attempt to do it automatically,
+                            in such a case must provide 'del_service_authS_tr' parameter or as 'DL_SERVICE_AUTH_STR'
+                            env var.
+        dl_service_auth_str: Optional[str] - string on the format 'tenant_id:service_id:service_secret'. To perform
+                                             authentication automatically; will default to DL_SERVICE_AUTH_STR env var or None
+
+        """
+        self.storename = storename
+        self.interactive = interactive
+        self.dl_service_auth_str = dl_service_auth_str or os.environ.get(
+            "DL_SERVICE_AUTH_STR"
+        )
+
+    def load_dataframes(
+        self, from_ts: datetime, to_ts: datetime, tag_list: List[str]
+    ) -> Iterable[pd.DataFrame]:
+        """
+        See GordoBaseDataProvider for documentation
+        """
+        adls_file_system_client = self.create_adls_client()
+
+        years = range(from_ts.year, to_ts.year + 1)
+
+        for tag in tag_list:
+            logger.info(f"Processing tag {tag}")
+
+            tag_frame_all_years = self.read_tag_files(
+                adls_file_system_client, tag, years
+            )
+            filtered = tag_frame_all_years[
+                (tag_frame_all_years.index >= from_ts)
+                & (tag_frame_all_years.index < to_ts)
+            ]
+            yield filtered
+
+    def read_tag_files(
+        self, adls_file_system_client: core.AzureDLFileSystem, tag: str, years: range
+    ) -> pd.DataFrame:
+        """
+        Download tag files for the given years into dataframes,
+        and return as one dataframe.
+
+        Parameters
+        ----------
+        adls_file_system_client: core.AzureDLFileSystem -
+                                 the AzureDLFileSystem client to use
+        tag: str - the tag to download data for
+        years: range - range object providing years to include
+
+        Returns
+        -------
+        pd.DataFrame: Single dataframe with all years for one tag.
+
+        """
+        tag_base_path = self.base_path_from_tag(tag)
+        all_years = []
+        for year in years:
+            file_path = tag_base_path + f"/{tag}/{tag}_{year}.csv"
+            logger.info(f"Parsing file {file_path}")
+
+            info = adls_file_system_client.info(file_path)
+            file_size = info.get("length") / (1024 ** 2)
+            logger.info(f"File size: {file_size:.2f}MB")
+
+            with adls_file_system_client.open(file_path, "rb") as f:
+                df = pd.read_csv(
+                    f,
+                    sep=";",
+                    header=None,
+                    names=["Sensor", tag, "Timestamp", "Status"],
+                    usecols=[tag, "Timestamp"],
+                    dtype={tag: np.float32},
+                    parse_dates=["Timestamp"],
+                    date_parser=lambda col: pd.to_datetime(col, utc=True),
+                    index_col="Timestamp",
+                )
+
+                all_years.append(df)
+                logger.info(f"Done parsing file {file_path}")
+
+        combined = pd.concat(all_years)
+
+        # There often comes duplicated timestamps, keep the last
+        if combined.index.duplicated().any():
+            combined = combined[~combined.index.duplicated(keep="last")]
+
+        return combined
+
+    def create_adls_client(self) -> core.AzureDLFileSystem:
+        """
+        Create ADLS file system client
+
+        Returns
+        -------
+        core.AzureDLFileSystem: Instance of AzureDLFileSystem, ready for use
+        """
+
+        if self.interactive:
+            token = self.get_datalake_token(interactive=True)
+
+        else:
+            token = self.get_datalake_token(
+                interactive=False, dl_service_auth_str=self.dl_service_auth_str
+            )
+
+        adls_file_system_client = core.AzureDLFileSystem(
+            token, store_name=self.storename
+        )
+        return adls_file_system_client
+
+    @staticmethod
+    def get_datalake_token(
+        interactive=True, dl_service_auth_str=None
+    ) -> lib.DataLakeCredential:
+        logger.info("Looking for ways to authenticate with data lake")
+        if interactive:
+            return lib.auth()
+
+        elif dl_service_auth_str:
+            logger.info("Attempting to use datalake service authentication")
+            dl_service_auth_elems = dl_service_auth_str.split(":")
+            tenant = dl_service_auth_elems[0]
+            client_id = dl_service_auth_elems[1]
+            client_secret = dl_service_auth_elems[2]
+            token = lib.auth(
+                tenant_id=tenant,
+                client_secret=client_secret,
+                client_id=client_id,
+                resource="https://datalake.azure.net/",
+            )
+            return token
+
+        else:
+            raise ValueError(
+                f"Either interactive (value: {interactive}) must be True, "
+                f"or dl_service_auth_str (value: {dl_service_auth_str}) "
+                "must be set. "
+            )
+
+    def base_path_from_tag(self, tag):
+        """
+
+        :param tag:
+        :return:
+        """
+        tag = tag.lower()
+        logger.debug(f"Looking for pattern for tag {tag}")
+
+        for pattern in self.TAG_TO_PATH:
+            if pattern[0].match(tag):
+                logger.info(
+                    f"Found pattern {pattern[0]} in tag {tag}, returning {pattern[1]}"
+                )
+                return pattern[1]
+
+        raise ValueError(f"Unable to find base path from tag {tag}")
+
+
+class InfluxDataProvider(GordoBaseDataProvider):
+    def __init__(self, measurement: str, **kwargs):
+        """
+        Parameters
+        ----------
+        measurement: str - Name of the measurement to select from in Influx
+        kwargs: dict - These are passed directly to the init args of influxdb.DataFrameClient
+        """
+        self.measurement = measurement
+        self.influx_config = kwargs
+        self.influx_client = DataFrameClient(**kwargs)
+
+    def load_dataframes(
+        self, from_ts: datetime, to_ts: datetime, tag_list: List[str]
+    ) -> Iterable[pd.DataFrame]:
+        """
+        See GordoBaseDataProvider for documentation
+        """
+        return (
+            self.read_single_sensor(
+                from_ts=from_ts, to_ts=to_ts, tag=tag, measurement=self.measurement
+            )
+            for tag in tag_list
+        )
+
+    def read_single_sensor(
+        self, from_ts: datetime, to_ts: datetime, tag: str, measurement: str
+    ) -> pd.DataFrame:
+        """
+        Parameters
+        ----------
+            from_ts: datetime - Datetime to start querying for data
+            to_ts: datetime - Datetime to stop query for data
+            tag: str - Name of the tag to match in influx
+            measurement: str - name of the measurement to select from
+        Returns
+        -------
+            One column DataFrame
+        """
+
+        logger.info(f"Reading tag: {tag}")
+        logger.info(f"Fetching data from {from_ts} to {to_ts}")
+        query_string = f"""
+            SELECT "Value" as "{tag}" 
+            FROM "{measurement}" 
+            WHERE("tag" =~ /^{tag}$/) 
+                {f"AND time >= {int(from_ts.timestamp())}s" if from_ts else ""} 
+                {f"AND time <= {int(to_ts.timestamp())}s" if to_ts else ""}
+        """
+        logger.info(f"Query string: {query_string}")
+        dataframes = self.influx_client.query(query_string)
+
+        list_of_tags = self._list_of_tags_from_influx()
+        if tag not in list_of_tags:
+            raise ValueError(
+                f"tag {tag} is not a valid tag.  List of tags = {list_of_tags}"
+            )
+
+        try:
+            vals = dataframes.values()
+            result = list(vals)[0]
+            return result
+
+        except IndexError as e:
+            logger.error(
+                f"Unable to find data for tag {tag} in the time range {from_ts} - {to_ts}"
+            )
+            raise e
+
+    def _list_of_tags_from_influx(self):
+        query_tags = (
+            f"""SHOW TAG VALUES ON {self.influx_config["database"]} WITH KEY="tag" """
+        )
+        result = self.influx_client.query(query_tags)
+        list_of_tags = []
+        for item in list(result.get_points()):
+            list_of_tags.append(item["value"])
+        return list_of_tags

--- a/gordo_components/dataset/base.py
+++ b/gordo_components/dataset/base.py
@@ -1,15 +1,17 @@
 # -*- coding: utf-8 -*-
 
 import abc
+import logging
+from typing import Iterable
+from datetime import datetime
+
+import pandas as pd
+import numpy as np
+
+logger = logging.getLogger(__name__)
 
 
 class GordoBaseDataset:
-    @abc.abstractmethod
-    def __init__(self, **kwargs):
-        """
-        Initialize the dataset.
-        """
-
     @abc.abstractmethod
     def get_data(self):
         """
@@ -20,5 +22,75 @@ class GordoBaseDataset:
     @abc.abstractmethod
     def get_metadata(self):
         """
-        Returns metadata (e.g. tag_list, train_start_date, train_end_date in InfluxBackedDataset class)
+        Return metadata about the dataset in primitive / json encode-able dict form.
         """
+
+    @staticmethod
+    def join_timeseries(
+        dataframes: Iterable[pd.DataFrame],
+        resampling_startpoint: datetime,
+        resolution: str,
+    ) -> pd.DataFrame:
+        """
+
+        Parameters
+        ----------
+        dataframes - An iterator supplying [timestamp, value] dataframes
+
+        resampling_startpoint - The starting point for resampling. Most data
+        frames will not have this in their datetime index, and it will be inserted with a
+        NaN as the value.
+        The resulting NaNs will be removed, so the only important requirement for this is
+        that this resampling_startpoint datetime must be before or equal to the first
+        (earliest) datetime in the data to be resampled.
+
+        resolution - The bucket size for grouping all incoming time data (e.g. "10T")
+
+        Returns
+        -------
+        pd.DataFrame - A dataframe without NaNs, a common time index, and one column per
+        element in the dataframe_generator
+
+        """
+        resampled_frames = []
+
+        for dataframe in dataframes:
+            startpoint_sametz = resampling_startpoint.astimezone(
+                tz=dataframe.index[0].tzinfo
+            )
+            if dataframe.index[0] > startpoint_sametz:
+                # Insert a NaN at the startpoint, to make sure that all resampled
+                # indexes are the same. This approach will "pad" most frames with
+                # NaNs, that will be removed at the end.
+                startpoint = pd.DataFrame(
+                    [np.NaN], index=[startpoint_sametz], columns=dataframe.columns
+                )
+                dataframe = startpoint.append(dataframe)
+                logging.debug(
+                    f"Appending NaN to {dataframe.columns[0]} "
+                    f"at time {startpoint_sametz}"
+                )
+
+            elif dataframe.index[0] < resampling_startpoint:
+                msg = (
+                    f"Error - for {dataframe.columns[0]}, first timestamp "
+                    f"{dataframe.index[0]} is before resampling start point "
+                    f"{startpoint_sametz}"
+                )
+                logging.error(msg)
+                raise RuntimeError(msg)
+
+            logging.debug("Head (3) and tail(3) of dataframe to be resampled:")
+            logging.debug(dataframe.head(3))
+            logging.debug(dataframe.tail(3))
+
+            resampled = dataframe.resample(resolution).mean()
+
+            filled = resampled.fillna(method="ffill")
+            resampled_frames.append(filled)
+
+        joined = pd.concat(resampled_frames, axis=1, join="inner")
+        # Before returning, delete all rows with NaN, they were introduced by the
+        # insertion of NaNs in the beginning of all timeseries
+
+        return joined.dropna()

--- a/gordo_components/dataset/datasets.py
+++ b/gordo_components/dataset/datasets.py
@@ -1,144 +1,32 @@
 # -*- coding: utf-8 -*-
 
-import os
-import re
 from typing import Iterable
 import logging
 import numpy as np
 import pandas as pd
-from influxdb import DataFrameClient
-from azure.datalake.store import lib
-from azure.datalake.store import core
 from datetime import datetime
 
 from gordo_components.dataset.base import GordoBaseDataset
+from gordo_components.data_provider.base import GordoBaseDataProvider
 
 logger = logging.getLogger(__name__)
 
 
-def join_timeseries(
-    dataframe_iterator: Iterable[pd.DataFrame],
-    resampling_startpoint: datetime,
-    resolution: str,
-) -> pd.DataFrame:
-    """
-
-    Parameters
-    ----------
-    dataframe_iterator - An iterator supplying [timestamp, value] dataframes
-
-    resampling_startpoint - The starting point for resampling. Most data
-    frames will not have this in their datetime index, and it will be inserted with a
-    NaN as the value.
-    The resulting NaNs will be removed, so the only important requirement for this is
-    that this resampling_startpoint datetime must be before or equal to the first
-    (earliest) datetime in the data to be resampled.
-
-    resolution - The bucket size for grouping all incoming time data (e.g. "10T")
-
-    Returns
-    -------
-    pd.DataFrame - A dataframe without NaNs, a common time index, and one column per
-    element in the dataframe_generator
-
-    """
-    resampled_frames = []
-
-    for dataframe in dataframe_iterator:
-        startpoint_sametz = resampling_startpoint.astimezone(
-            tz=dataframe.index[0].tzinfo
-        )
-        if dataframe.index[0] > startpoint_sametz:
-            # Insert a NaN at the startpoint, to make sure that all resampled
-            # indexes are the same. This approach will "pad" most frames with
-            # NaNs, that will be removed at the end.
-            startpoint = pd.DataFrame(
-                [np.NaN], index=[startpoint_sametz], columns=dataframe.columns
-            )
-            dataframe = startpoint.append(dataframe)
-            logging.debug(
-                f"Appending NaN to {dataframe.columns[0]} "
-                f"at time {startpoint_sametz}"
-            )
-
-        elif dataframe.index[0] < resampling_startpoint:
-            msg = (
-                f"Error - for {dataframe.columns[0]}, first timestamp "
-                f"{dataframe.index[0]} is before resampling start point "
-                f"{startpoint_sametz}"
-            )
-            logging.error(msg)
-            raise RuntimeError(msg)
-
-        logging.debug("Head (3) and tail(3) of dataframe to be resampled:")
-        logging.debug(dataframe.head(3))
-        logging.debug(dataframe.tail(3))
-
-        resampled = dataframe.resample(resolution).mean()
-
-        filled = resampled.fillna(method="ffill")
-        resampled_frames.append(filled)
-
-    joined = pd.concat(resampled_frames, axis=1, join="inner")
-    # Before returning, delete all rows with NaN, they were introduced by the
-    # insertion of NaNs in the beginning of all timeseries
-
-    return joined.dropna()
-
-
-class DataLakeBackedDataset(GordoBaseDataset):
-    TAG_TO_PATH = [
-        (
-            re.compile(r"^asgb."),
-            "/raw/corporate/PI System Operation North/sensordata/1191-ASGB",
-        ),
-        (
-            re.compile(r"^gra."),
-            "/raw/corporate/Aspen MS - IP21 Grane/sensordata/1755-GRA",
-        ),
-        (
-            re.compile(r"^1125."),
-            "/raw/corporate/PI System Operation Norway/sensordata/1125-KVB",
-        ),
-        (
-            re.compile(r"^trb."),
-            "/raw/corporate/Aspen MS - IP21 Troll B/sensordata/1775-TROB",
-        ),
-        (
-            re.compile(r"^trc."),
-            "/raw/corporate/Aspen MS - IP21 Troll C/sensordata/1776-TROC",
-        ),
-    ]
-
+class TimeSeriesDataset(GordoBaseDataset):
     def __init__(
         self,
-        datalake_config: dict,
+        data_provider: GordoBaseDataProvider,
         from_ts: datetime,
         to_ts: datetime,
         tag_list: list,
         resolution: str = "10T",
+        **_kwargs,
     ):
-        """
-        Instantiates a DataLakeBackedDataset, for fetching of data from the data lake
-        Parameters
-        ----------
-        datalake_config: dict - Datalake specific information, in particular
-                        'dl_service_auth_str' and 'storename'
-                        The 'dl_service_auth_str' is a string on the format
-                        'tenant_id:service_id:service_secret'.
-                        These parameters must be obtained from the DataLake admins,
-                        or a key-store or similar.
-        from_ts: datetime.datetime - start time for returned data (inclusive)
-        to_ts: datetime.datetime - end time for returned data (non-inclusive)
-        tag_list: list - list of tags to fetch data for
-        resolution: str - the resolution to be used for resampling, in Pandas syntax
-        """
-        self.datalake_config = datalake_config
         self.from_ts = from_ts
         self.to_ts = to_ts
         self.tag_list = tag_list
         self.resolution = resolution
-        self.interactive = self.datalake_config.get("interactive", False)
+        self.data_provider = data_provider
 
         if not self.from_ts.tzinfo or not self.to_ts.tzinfo:
             raise ValueError(
@@ -147,289 +35,13 @@ class DataLakeBackedDataset(GordoBaseDataset):
             )
 
     def get_data(self) -> pd.DataFrame:
-        dataframe_generator = self.make_dataframe_generator()
+        dataframe_generator = self.data_provider.load_dataframes(
+            from_ts=self.from_ts, to_ts=self.to_ts, tag_list=self.tag_list
+        )
 
-        X = join_timeseries(dataframe_generator, self.from_ts, self.resolution)
+        X = self.join_timeseries(dataframe_generator, self.from_ts, self.resolution)
         y = None
         return X, y
-
-    def make_dataframe_generator(self):
-        """
-        Based on the config set in the constructor, return a data-frame with all data.
-        The data will be resampled, and not contain NaNs.
-        Returns
-        -------
-        pd.DataFrame: The data frame with all tags.
-        """
-        adls_file_system_client = self.create_adls_client(self.interactive)
-
-        years = range(self.from_ts.year, self.to_ts.year + 1)
-
-        for tag in self.tag_list:
-            logger.info(f"Processing tag {tag}")
-
-            tag_frame_all_years = self.read_tag_files(
-                adls_file_system_client, tag, years
-            )
-            filtered = tag_frame_all_years[
-                (tag_frame_all_years.index >= self.from_ts)
-                & (tag_frame_all_years.index < self.to_ts)
-            ]
-            yield filtered
-
-    def read_tag_files(
-        self, adls_file_system_client: core.AzureDLFileSystem, tag: str, years: range
-    ) -> pd.DataFrame:
-        """
-        Download tag files for the given years into dataframes,
-        and return as one dataframe.
-
-        Parameters
-        ----------
-        adls_file_system_client: core.AzureDLFileSystem -
-                                 the AzureDLFileSystem client to use
-        tag: str - the tag to download data for
-        years: range - range object providing years to include
-
-        Returns
-        -------
-        pd.DataFrame: Single dataframe with all years for one tag.
-
-        """
-        tag_base_path = self.base_path_from_tag(tag)
-        all_years = []
-        for year in years:
-            file_path = tag_base_path + f"/{tag}/{tag}_{year}.csv"
-            logger.info(f"Parsing file {file_path}")
-
-            info = adls_file_system_client.info(file_path)
-            file_size = info.get("length") / (1024 ** 2)
-            logger.info(f"File size: {file_size:.2f}MB")
-
-            with adls_file_system_client.open(file_path, "rb") as f:
-                df = pd.read_csv(
-                    f,
-                    sep=";",
-                    header=None,
-                    names=["Sensor", tag, "Timestamp", "Status"],
-                    usecols=[tag, "Timestamp"],
-                    dtype={tag: np.float32},
-                    parse_dates=["Timestamp"],
-                    date_parser=lambda col: pd.to_datetime(col, utc=True),
-                    index_col="Timestamp",
-                )
-
-                all_years.append(df)
-                logger.info(f"Done parsing file {file_path}")
-
-        combined = pd.concat(all_years)
-
-        # There often comes duplicated timestamps, keep the last
-        if combined.index.duplicated().any():
-            combined = combined[~combined.index.duplicated(keep="last")]
-
-        return combined
-
-    def create_adls_client(self, interactive) -> core.AzureDLFileSystem:
-        """
-        Create ADLS file system client based on the 'datalake_config' object
-
-        Returns
-        -------
-        core.AzureDLFileSystem: Instance of AzureDLFileSystem, ready for use
-        """
-        azure_data_store = self.datalake_config.get("storename")
-
-        if interactive:
-            token = self.get_datalake_token(interactive=True)
-
-        else:
-            dl_service_auth_str = self.datalake_config.get(
-                "dl_service_auth_str", os.environ.get("DL_SERVICE_AUTH_STR")
-            )
-            token = self.get_datalake_token(
-                interactive=False, dl_service_auth_str=dl_service_auth_str
-            )
-
-        adls_file_system_client = core.AzureDLFileSystem(
-            token, store_name=azure_data_store
-        )
-        return adls_file_system_client
-
-    @staticmethod
-    def get_datalake_token(
-        interactive=True, dl_service_auth_str=None
-    ) -> lib.DataLakeCredential:
-        logger.info("Looking for ways to authenticate with data lake")
-        if interactive:
-            return lib.auth()
-
-        elif dl_service_auth_str:
-            logger.info("Attempting to use datalake service authentication")
-            dl_service_auth_elems = dl_service_auth_str.split(":")
-            tenant = dl_service_auth_elems[0]
-            client_id = dl_service_auth_elems[1]
-            client_secret = dl_service_auth_elems[2]
-            token = lib.auth(
-                tenant_id=tenant,
-                client_secret=client_secret,
-                client_id=client_id,
-                resource="https://datalake.azure.net/",
-            )
-            return token
-
-        else:
-            raise ValueError(
-                f"Either interactive (value: {interactive}) must be True, "
-                f"or dl_service_auth_str (value: {dl_service_auth_str}) "
-                "must be set. "
-            )
-
-    def get_metadata(self):
-        metadata = {
-            "tag_list": self.tag_list,
-            "train_start_date": self.from_ts,
-            "train_end_date": self.to_ts,
-            "resolution": self.resolution,
-        }
-        return metadata
-
-    def base_path_from_tag(self, tag):
-        """
-
-        :param tag:
-        :return:
-        """
-        tag = tag.lower()
-        logger.debug(f"Looking for pattern for tag {tag}")
-
-        for pattern in self.TAG_TO_PATH:
-            if pattern[0].match(tag):
-                logger.info(
-                    f"Found pattern {pattern[0]} in tag {tag}, returning {pattern[1]}"
-                )
-                return pattern[1]
-
-        raise ValueError(f"Unable to find base path from tag {tag}")
-
-
-class InfluxBackedDataset(GordoBaseDataset):
-    def __init__(
-        self,
-        influx_config,
-        from_ts,
-        to_ts,
-        tag_list=None,
-        resolution="10m",
-        resample=True,
-        **kwargs,
-    ):
-        """
-        TODO: Finish docs
-
-        Parameters
-        ----------
-            influx_config: dict - Configuration for InfluxDB connection with keys:
-                host, port, username, password, database
-            tag_list: List[str] - List of tags
-            from_ts: timestamp: start date of training period
-            to_ts  : timestamp: end date of training period
-            resolution: str - ie. "10m"
-            resample: bool - Whether to resample.
-        """
-        self.to_ts = to_ts
-        self.tag_list = tag_list
-        self.from_ts = from_ts
-        self.resample = resample
-        self.resolution = resolution
-        self.influx_config = influx_config
-        self.influx_client = DataFrameClient(**influx_config)
-
-    def get_data(self):
-        X = self._get_sensor_data()
-        y = None
-        return X, y
-
-    def read_single_sensor(self, tag):
-        """
-        Parameters
-        ----------
-            tag: str - The tag attached to the timeseries
-
-        Returns
-        -------
-            One column DataFrame
-        """
-
-        logger.info(f"Reading tag: {tag}")
-        logger.info(f"Fetching data from {self.from_ts} to {self.to_ts}")
-        measurement = self.influx_config["database"]
-        query_string = f"""
-            SELECT {'mean("Value")' if self.resample else '"Value"'} as "{tag}" 
-            FROM "{measurement}" 
-            WHERE("tag" =~ /^{tag}$/) 
-                {f"AND time >= {int(self.from_ts.timestamp())}s" if self.from_ts else ""} 
-                {f"AND time <= {int(self.to_ts.timestamp())}s" if self.to_ts else ""} 
-            {f'GROUP BY time({self.resolution}), "tag" fill(previous)' if self.resample else ""}
-        """
-        logger.info(f"Query string: {query_string}")
-        dataframes = self.influx_client.query(query_string)
-
-        list_of_tags = self._list_of_tags_from_influx()
-        if tag not in list_of_tags:
-            raise ValueError(
-                f"tag {tag} is not a valid tag.  List of tags = {list_of_tags}"
-            )
-
-        try:
-            vals = dataframes.values()
-            result = list(vals)[0]
-            return result
-
-        except IndexError as e:
-            logger.error(
-                f"Unable to find data for tag {tag} in the time range {self.from_ts} - {self.to_ts}"
-            )
-            raise e
-
-    def _list_of_tags_from_influx(self):
-        query_tags = (
-            f"""SHOW TAG VALUES ON {self.influx_config["database"]} WITH KEY="tag" """
-        )
-        result = self.influx_client.query(query_tags)
-        list_of_tags = []
-        for item in list(result.get_points()):
-            list_of_tags.append(item["value"])
-        return list_of_tags
-
-    def _get_sensor_data(self):
-        """
-        Returns:
-            A single dataframe with all sensors. Note, due to potential leading
-            NaNs (which are removed) the from_ts might differ from the
-            resulting first timestamp in the dataframe
-        """
-        if self.tag_list is None:
-            self.tag_list = []
-
-        logger.info(f"Taglist:\n{self.tag_list}")
-        sensors = []
-        for tag in self.tag_list:
-            single_sensor = self.read_single_sensor(tag)
-            sensors.append(single_sensor)
-
-        all_tags = pd.concat(sensors, axis=1)
-
-        # TODO: This should be removed after mvp
-        first_valid = all_tags[all_tags.notnull().all(axis=1)].index[0]
-        if first_valid != all_tags.index[0]:
-            logger.warning("Removing first part of data due to NaN")
-            logger.warning(
-                f"Starting at {first_valid} instead of " f"{all_tags.index[0]}"
-            )
-            all_tags = all_tags[first_valid:]
-
-        return all_tags
 
     def get_metadata(self):
         metadata = {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,8 +41,8 @@ class CliTestCase(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             with temp_env_vars(
                 OUTPUT_DIR=tmpdir,
-                DATA_CONFIG='{"type": "RandomDataset", "train_start_date": "2015-01-01",'
-                ' "train_end_date": "2015-06-01", "tags": ["tag1", "tag2"]}',
+                DATA_CONFIG='{"type": "RandomDataset", "train_start_date": "2015-01-01T00:00:00+00:00",'
+                ' "train_end_date": "2015-06-01T00:00:00+00:00", "tags": ["tag1", "tag2"]}',
                 MODEL_CONFIG=json.dumps(model_config),
             ):
                 result = self.runner.invoke(cli.gordo, ["build"])

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -8,7 +8,7 @@ import dateutil.parser
 
 from gordo_components.dataset import _get_dataset
 from gordo_components.dataset.base import GordoBaseDataset
-from gordo_components.dataset.datasets import RandomDataset, join_timeseries
+from gordo_components.dataset.datasets import RandomDataset
 
 
 class DatasetTestCase(unittest.TestCase):
@@ -44,7 +44,9 @@ class DatasetTestCase(unittest.TestCase):
         frequency = "7T"
         timedelta = pd.Timedelta("7 minutes")
         resampling_start = dateutil.parser.isoparse("2017-12-25 06:00:00Z")
-        all_in_frame = join_timeseries(timeseries_list, resampling_start, frequency)
+        all_in_frame = GordoBaseDataset.join_timeseries(
+            timeseries_list, resampling_start, frequency
+        )
 
         # Check that first resulting resampled, joined row is within "frequency" from
         # the real first data point
@@ -57,7 +59,9 @@ class DatasetTestCase(unittest.TestCase):
         timeseries_list, latest_start, earliest_end = self.create_timeseries_list()
         frequency = "7T"
         resampling_start = dateutil.parser.isoparse("2017-12-25 06:00:00+07:00")
-        all_in_frame = join_timeseries(timeseries_list, resampling_start, frequency)
+        all_in_frame = GordoBaseDataset.join_timeseries(
+            timeseries_list, resampling_start, frequency
+        )
         self.assertEqual(len(all_in_frame), 413)
 
     def test_join_timeseries_with_gaps(self):
@@ -75,7 +79,7 @@ class DatasetTestCase(unittest.TestCase):
 
         frequency = "10T"
         resampling_start = dateutil.parser.isoparse("2017-12-25 06:00:00Z")
-        all_in_frame = join_timeseries(
+        all_in_frame = GordoBaseDataset.join_timeseries(
             timeseries_with_holes, resampling_start, frequency
         )
         self.assertEqual(all_in_frame.index[0], pd.Timestamp(latest_start))

--- a/tests/test_examples_jupyter.py
+++ b/tests/test_examples_jupyter.py
@@ -17,8 +17,8 @@ import numpy as np
 
 from nbconvert.exporters import PythonExporter
 
-from gordo_components.dataset.datasets import DataLakeBackedDataset
-
+from gordo_components.data_provider.providers import DataLakeProvider
+from gordo_components.dataset.datasets import TimeSeriesDataset
 
 logger = logging.getLogger(__name__)
 
@@ -29,11 +29,10 @@ def _fake_data():
 
 
 class ExampleNotebooksTestCase(unittest.TestCase):
-    @mock.patch.object(DataLakeBackedDataset, "get_data", return_value=_fake_data())
+    @mock.patch.object(TimeSeriesDataset, "get_data", return_value=_fake_data())
     def test_faked_DataLakeBackedDataset(self, _mocked_method):
 
-        dataset = DataLakeBackedDataset(
-            datalake_config={"storename": "dataplatformdlsprod", "interactive": True},
+        config = dict(
             from_ts=dateutil.parser.isoparse("2014-07-01T00:10:00+00:00"),
             to_ts=dateutil.parser.isoparse("2015-01-01T00:00:00+00:00"),
             tag_list=[
@@ -42,10 +41,13 @@ class ExampleNotebooksTestCase(unittest.TestCase):
             ],
         )
 
+        provider = DataLakeProvider(storename="dataplatformdlsprod", interactive=True)
+        dataset = TimeSeriesDataset(data_provider=provider, **config)
+
         # Should be able to call get_data without being asked to authenticate in tests
         X, y = dataset.get_data()
 
-    @mock.patch.object(DataLakeBackedDataset, "get_data", return_value=_fake_data())
+    @mock.patch.object(TimeSeriesDataset, "get_data", return_value=_fake_data())
     def test_notebooks(self, _mocked_method):
         """
         Ensures all notebooks will run without error


### PR DESCRIPTION
Will close #121 

InfluxBackedDataset and now DataLakeBackedDataset exposed a neeed to
treat the Dataset separate from where the data itself was coming from.

We now use dependency injection from Dataset to use a 'data_provider' to
fetch the data itself. And Dataset object will have their own properties
specific to Dataset operations