### PR TITLE
Iroc data source

### DIFF
--- a/gordo_components/data_provider/azure_utils.py
+++ b/gordo_components/data_provider/azure_utils.py
@@ -1,0 +1,125 @@
+# -*- coding: utf-8 -*-
+import collections
+import re
+import logging
+from typing import AnyStr
+
+from azure.datalake.store import core, lib
+from typing.re import Pattern
+
+logger = logging.getLogger(__name__)
+
+
+def get_datalake_token(
+    interactive=True, dl_service_auth_str=None
+) -> lib.DataLakeCredential:
+    """
+    Provides a token for azure datalake, either by parsing a datalake service
+    authentication string or using interactive authentication
+
+    Parameters
+    ----------
+    interactive
+        If true then fall back to interactive authentication in case
+        `dl_service_auth_str` is empty
+    dl_service_auth_str
+        String on the format tenant:client_id:client_secret
+
+    Returns
+    -------
+    lib.DataLakeCredential
+        A lib.DataLakeCredential which can be used to authenticate towards the datalake
+    """
+    logger.info("Looking for ways to authenticate with data lake")
+    if dl_service_auth_str:
+        logger.info("Attempting to use datalake service authentication")
+        dl_service_auth_elems = dl_service_auth_str.split(":")
+        tenant = dl_service_auth_elems[0]
+        client_id = dl_service_auth_elems[1]
+        client_secret = dl_service_auth_elems[2]
+        token = lib.auth(
+            tenant_id=tenant,
+            client_secret=client_secret,
+            client_id=client_id,
+            resource="https://datalake.azure.net/",
+        )
+        return token
+    elif interactive:
+        logger.info("Attempting to use interactive azure authentication")
+        return lib.auth()
+    else:
+        raise ValueError(
+            f"Either interactive (value: {interactive}) must be True, "
+            f"or dl_service_auth_str (value: {dl_service_auth_str}) "
+            "must be set. "
+        )
+
+
+def create_adls_client(
+    storename: str, dl_service_auth_str: str = None, interactive: bool = False
+) -> core.AzureDLFileSystem:
+    """
+    Creates an ADLS file system client.
+
+    Parameters
+    ----------
+    storename
+        Name of datalake store.
+    dl_service_auth_str
+        Authentication string to use
+    interactive
+        If true then use interactive authentication if dl_service_auth_str is not set
+
+
+    Returns
+    -------
+    core.AzureDLFileSystem
+        Instance of AzureDLFileSystem, ready to use
+    """
+    token = get_datalake_token(
+        interactive=interactive, dl_service_auth_str=dl_service_auth_str
+    )
+
+    adls_file_system_client = core.AzureDLFileSystem(token, store_name=storename)
+    return adls_file_system_client
+
+
+def walk_azure(
+    client: core.AzureDLFileSystem,
+    base_path: str,
+    include_regexp: Pattern[AnyStr] = re.compile(".*"),
+    exclude_regexp: Pattern[AnyStr] = re.compile("a^"),
+):
+    """
+    Walks azure datalake `azure_data_store` in a depth-first fashion from
+    `base_path`, yielding files which match `include_re` AND not match `exclude_re`
+
+    Notes
+    -----
+    If `base_path` does not exist then the generator returns nothing, it does not fail.
+
+    """
+    logger.info(
+        "Starting a azure walk with base_path: {} with include_regexp: {} "
+        "and exclude_regexp: {}".format(base_path, include_regexp, exclude_regexp)
+    )
+
+    adls_file_system_client = client
+    if not adls_file_system_client.exists(base_path):
+        return
+    fringe = collections.deque(adls_file_system_client.ls(base_path, detail=True))
+    while fringe:
+        a_path = fringe.pop()
+        if a_path["type"] == "DIRECTORY":
+            logger.info("Expanding the directory %s" % a_path["name"])
+            fringe.extend(adls_file_system_client.ls(a_path["name"], detail=True))
+        if a_path["type"] == "FILE":
+            file_path = a_path["name"]
+            if include_regexp.match(file_path) and not exclude_regexp.match(file_path):
+                logger.info("Returning the file_path %s" % file_path)
+                yield file_path
+            else:
+                logger.info(
+                    f"Found that the file_path {file_path} does not satisfy regexp "
+                    f"requirements"
+                )

--- a/gordo_components/data_provider/base.py
+++ b/gordo_components/data_provider/base.py
@@ -28,3 +28,16 @@ class GordoBaseDataProvider(abc.ABC):
         Iterable[pd.DataFrame]
         """
         ...
+
+    @abc.abstractmethod
+    def __init__(self, **kwargs):
+        ...
+
+    @abc.abstractmethod
+    def can_handle_tag(self, tag):
+        """ Returns true if the dataprovider thinks it can possibly read this tag.
+
+        Does not guarantee success, but is should be a pretty good guess
+        (typically a regular expression is used to determine of the reader can read the
+        tag)"""
+        ...

--- a/gordo_components/data_provider/iroc_reader.py
+++ b/gordo_components/data_provider/iroc_reader.py
@@ -1,0 +1,158 @@
+# -*- coding: utf-8 -*-
+import re
+import logging
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime
+from typing import Iterable, List
+
+import pandas as pd
+from azure.datalake.store import core
+
+from gordo_components.data_provider.azure_utils import walk_azure
+from gordo_components.data_provider.base import GordoBaseDataProvider
+
+logger = logging.getLogger(__name__)
+
+
+class IrocReader(GordoBaseDataProvider):
+
+    REGEXP_FOR_TAGS = re.compile(r"^NINENINE.+::.+")
+
+    def can_handle_tag(self, tag):
+        return IrocReader.REGEXP_FOR_TAGS.match(tag)
+
+    def __init__(self, client: core.AzureDLFileSystem, threads: int = 50, **kwargs):
+        """
+        Creates a reader for tags from IROC.
+        """
+        super().__init__(**kwargs)
+        self.client = client
+        self.threads = threads
+
+    def load_dataframes(
+        self,
+        from_ts: datetime,
+        to_ts: datetime,
+        tag_list: List[str],
+        base_path="raw/plant/uon/cygnet/ninenine/history",
+    ):
+        """
+        See GordoBaseDataProvider for documentation
+        """
+
+        base_path = base_path.strip("/")
+
+        # We query with an extra day on both sides since the way the files are
+        # organized in the datalake does not account for timezones, so some timestamps
+        # are in the wrong files
+
+        all_base_paths = (
+            f"{base_path}/{t.year:0>4d}/{t.month:0>2d}/{t.day:0>2d}/"
+            for t in pd.date_range(
+                start=from_ts - pd.Timedelta("1D"),
+                end=to_ts + pd.Timedelta("1D"),
+                freq="D",
+            )
+        )
+
+        fetched_tags = self._fetch_all_iroc_files_from_paths(
+            all_base_paths, from_ts, to_ts, tag_list
+        )
+        if len(fetched_tags) < 0:
+            raise ValueError(
+                f"Found no data for tags {tag_list} in the daterange {from_ts} to "
+                f"{to_ts}"
+            )
+
+        concatted = pd.concat(fetched_tags, copy=False)
+
+        if len(concatted.columns) != len(tag_list):
+            raise ValueError(
+                f"Did not find data for all tags, the missing tags are "
+                f"{set(tag_list)-set(concatted.columns)}"
+            )
+
+        for col in concatted.columns:
+            withouth_na = concatted[[col]].dropna()
+            withouth_na.sort_index(inplace=True)
+            yield withouth_na
+
+    def _fetch_all_iroc_files_from_paths(
+        self,
+        all_base_paths: Iterable[str],
+        from_ts: datetime,
+        to_ts: datetime,
+        tag_list: List[str],
+    ):
+        # Generator over all files in all of the base_paths
+        def _all_files():
+            for b_path in all_base_paths:
+                for f in walk_azure(client=self.client, base_path=b_path):
+                    yield f
+
+        with ThreadPoolExecutor(max_workers=self.threads) as executor:
+            # Pandas.concat makes the generator into a list anyway, so no extra memory
+            # is used here
+            fetched_tags = list(
+                executor.map(
+                    lambda file_path: self._read_iroc_df_from_azure(
+                        file_path=file_path,
+                        from_ts=from_ts,
+                        to_ts=to_ts,
+                        tag_list=tag_list,
+                    ),
+                    _all_files(),
+                )
+            )
+        return fetched_tags
+
+    def _read_iroc_df_from_azure(
+        self, file_path, from_ts: datetime, to_ts: datetime, tag_list
+    ):
+        adls_file_system_client = self.client
+
+        logger.info("Attempting to open IROC file {}".format(file_path))
+        with adls_file_system_client.open(file_path, "rb") as f:
+            logger.info("Parsing file {}".format(file_path))
+            df = read_iroc_file(f, from_ts, to_ts, tag_list)
+        return df
+
+
+def read_iroc_file(
+    file_obj, from_ts: datetime, to_ts: datetime, tag_list: List[str]
+) -> pd.DataFrame:
+    """
+    Reads a single iroc timeseries csv, and returns it as a pandas.DataFrame.
+    The returned dataframe has timestamps as a DateTimeIndex, and upto one column
+    per tag in tag_list, but excluding any tags which does not exist in the csv.
+
+    Parameters
+    ----------
+    file_obj: str or path object or file-like object
+        File object to read iroc timeseries data from
+    from_ts
+        Only keep timestamps later or equal than this
+    to_ts
+        Only keep timestamps earlier than this
+    tag_list
+        Only keep tags in this list.
+
+    Returns
+    -------
+    pd.DataFrame
+        Dataframe with timestamps as a DateTimeIndex, and up to one column
+        per tag in tag_list, but excluding any tags which does not exist in the
+        csv.
+
+    """
+    df = pd.read_csv(file_obj, sep=",", usecols=["tag", "value", "timestamp"])
+    df = df[df["tag"].isin(tag_list)]
+    # Note, there are some "digital" sensors with string values,
+    # now they are just NaN converted
+    df["value"] = df["value"].apply(pd.to_numeric, errors="coerce", downcast="float")
+    df.dropna(inplace=True, subset=["value"])
+    df["timestamp"] = pd.to_datetime(df["timestamp"], utc=True)
+    df = df.pivot(index="timestamp", columns="tag")
+    df = df[(df.index >= from_ts) & (df.index < to_ts)]
+    df.columns = df.columns.droplevel(0)
+    return df

--- a/gordo_components/data_provider/ncs_reader.py
+++ b/gordo_components/data_provider/ncs_reader.py
@@ -1,0 +1,147 @@
+# -*- coding: utf-8 -*-
+import logging
+import re
+from datetime import datetime
+from typing import Iterable, List
+
+import numpy as np
+import pandas as pd
+from azure.datalake.store import core
+
+from gordo_components.data_provider.base import GordoBaseDataProvider
+
+logger = logging.getLogger(__name__)
+
+
+class NcsReader(GordoBaseDataProvider):
+    TAG_TO_PATH = [
+        (
+            re.compile(r"^asgb."),
+            "/raw/corporate/PI System Operation North/sensordata/1191-ASGB",
+        ),
+        (
+            re.compile(r"^gra."),
+            "/raw/corporate/Aspen MS - IP21 Grane/sensordata/1755-GRA",
+        ),
+        (
+            re.compile(r"^1125."),
+            "/raw/corporate/PI System Operation Norway/sensordata/1125-KVB",
+        ),
+        (
+            re.compile(r"^trb."),
+            "/raw/corporate/Aspen MS - IP21 Troll B/sensordata/1775-TROB",
+        ),
+        (
+            re.compile(r"^trc."),
+            "/raw/corporate/Aspen MS - IP21 Troll C/sensordata/1776-TROC",
+        ),
+    ]
+
+    def __init__(self, client: core.AzureDLFileSystem, **kwargs):
+        """
+        Creates a reader for tags from the Norwegian Continental Shelf. Currently
+        only supports a small subset of assets.
+
+        """
+        super().__init__(**kwargs)
+        self.client = client
+
+    def can_handle_tag(self, tag):
+        return NcsReader.base_path_from_tag(tag)
+
+    def load_dataframes(
+        self, from_ts: datetime, to_ts: datetime, tag_list: List[str]
+    ) -> Iterable[pd.DataFrame]:
+        """
+        See GordoBaseDataProvider for documentation
+        """
+        adls_file_system_client = self.client
+
+        years = range(from_ts.year, to_ts.year + 1)
+
+        for tag in tag_list:
+            logger.info(f"Processing tag {tag}")
+
+            tag_frame_all_years = self.read_tag_files(
+                adls_file_system_client, tag, years
+            )
+            filtered = tag_frame_all_years[
+                (tag_frame_all_years.index >= from_ts)
+                & (tag_frame_all_years.index < to_ts)
+            ]
+            yield filtered
+
+    @staticmethod
+    def read_tag_files(
+        adls_file_system_client: core.AzureDLFileSystem, tag: str, years: range
+    ) -> pd.DataFrame:
+        """
+        Download tag files for the given years into dataframes,
+        and return as one dataframe.
+
+        Parameters
+        ----------
+        adls_file_system_client: core.AzureDLFileSystem
+            the AzureDLFileSystem client to use
+        tag: str
+            the tag to download data for
+        years: range
+            range object providing years to include
+
+        Returns
+        -------
+        pd.DataFrame: Single dataframe with all years for one tag.
+
+        """
+        tag_base_path = NcsReader.base_path_from_tag(tag)
+        if not tag_base_path:
+            raise ValueError(f"Unable to find base path from tag {tag}")
+        all_years = []
+        for year in years:
+            file_path = tag_base_path + f"/{tag}/{tag}_{year}.csv"
+            logger.info(f"Parsing file {file_path}")
+
+            info = adls_file_system_client.info(file_path)
+            file_size = info.get("length") / (1024 ** 2)
+            logger.info(f"File size: {file_size:.2f}MB")
+
+            with adls_file_system_client.open(file_path, "rb") as f:
+                df = pd.read_csv(
+                    f,
+                    sep=";",
+                    header=None,
+                    names=["Sensor", tag, "Timestamp", "Status"],
+                    usecols=[tag, "Timestamp"],
+                    dtype={tag: np.float32},
+                    parse_dates=["Timestamp"],
+                    date_parser=lambda col: pd.to_datetime(col, utc=True),
+                    index_col="Timestamp",
+                )
+
+                all_years.append(df)
+                logger.info(f"Done parsing file {file_path}")
+
+        combined = pd.concat(all_years)
+
+        # There often comes duplicated timestamps, keep the last
+        if combined.index.duplicated().any():
+            combined = combined[~combined.index.duplicated(keep="last")]
+
+        return combined
+
+    @staticmethod
+    def base_path_from_tag(tag):
+        """
+        Resolves a tag to the datalake basepath it should reside. Returns None if
+        it does not match any of the tag-regexps we know.
+        """
+        tag = tag.lower()
+        logger.debug(f"Looking for pattern for tag {tag}")
+
+        for pattern in NcsReader.TAG_TO_PATH:
+            if pattern[0].match(tag):
+                logger.info(
+                    f"Found pattern {pattern[0]} in tag {tag}, returning {pattern[1]}"
+                )
+                return pattern[1]
+        return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ asn1crypto==0.24.0        # via cryptography
 astor==0.7.1              # via tensorflow
 attrs==19.1.0             # via jsonschema
 azure-datalake-store==0.0.43
+cachetools==3.1.0
 certifi==2018.11.29       # via requests
 cffi==1.12.2              # via azure-datalake-store, cryptography
 chardet==3.0.4            # via requests

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ from setuptools import setup, find_packages
 # Install requirements
 install_requires = [
     "Click~=7.0",
+    "cachetools~=3.1",
     "h5py~=2.8",
     "influxdb~=5.2",
     "joblib~=0.13",

--- a/tests/test_azure_utils.py
+++ b/tests/test_azure_utils.py
@@ -1,0 +1,14 @@
+import unittest
+import adal
+
+from gordo_components.data_provider.azure_utils import get_datalake_token
+
+
+class AzureUtilsTestCase(unittest.TestCase):
+    def test_get_datalake_token_wrong_args(self):
+        with self.assertRaises(ValueError):
+            get_datalake_token(interactive=False)
+
+    def test_get_data_serviceauth_fail(self):
+        with self.assertRaises(adal.adal_error.AdalError):
+            get_datalake_token(dl_service_auth_str="TENTANT_UNKNOWN:BOGUS:PASSWORD")

--- a/tests/test_data_provider_datalake.py
+++ b/tests/test_data_provider_datalake.py
@@ -1,11 +1,10 @@
 import os
-
 import dateutil.parser
 import unittest
 import adal
 
-from gordo_components.dataset import dataset
 from gordo_components.data_provider.providers import DataLakeProvider
+from gordo_components.dataset import dataset
 
 
 class DataLakeTestCase(unittest.TestCase):
@@ -85,7 +84,3 @@ class DataLakeTestCase(unittest.TestCase):
         self.assertFalse(
             data.isnull().values.any(), "Resulting dataframe should not have any NaNs"
         )
-
-    def test_get_datalake_token_wrong_args(self):
-        with self.assertRaises(ValueError):
-            DataLakeProvider.get_datalake_token(interactive=False)

--- a/tests/test_data_provider_influx.py
+++ b/tests/test_data_provider_influx.py
@@ -165,6 +165,21 @@ class PredictionInfluxTestCase(unittest.TestCase):
             msg=f"Expected tags = {expected_tags}" f"outputted {tags}",
         )
 
+    def test_get_list_of_tags(self):
+        ds = InfluxDataProvider(measurement=SOURCE_DB_NAME, **self.influx_config)
+        expected_tags = {
+            "TRC-FIQ -23-0453N",
+            "TRC-FIQ -80-0303N",
+            "TRC-FIQ -80-0703N",
+            "TRC-FIQ -80-0704N",
+            "TRC-FIQ -80-0705N",
+        }
+        tags = set(ds.get_list_of_tags())
+        self.assertSetEqual(expected_tags, tags)
+        # The cache does not screw stuff up
+        tags = set(ds.get_list_of_tags())
+        self.assertSetEqual(expected_tags, tags)
+
     def test_influx_dataset_attrs(self):
         """
         Test expected attributes

--- a/tests/test_data_provider_iroc.py
+++ b/tests/test_data_provider_iroc.py
@@ -1,0 +1,143 @@
+import unittest
+from io import StringIO
+from unittest import mock
+
+from dateutil.parser import isoparse  # type: ignore
+
+from gordo_components.data_provider.iroc_reader import IrocReader, read_iroc_file
+
+IROC_HAPPY_TAG_LIST = [
+    "NINENINE.OPCIS::NNFCDPC01.AI1410J0",
+    "NINENINE.OPCIS::NNFCDPC01.AI1840C1J0",
+    "NINENINE.OPCIS::NNFCDPC01.AI1840E1J0",
+]
+
+HAPPY_FROM_TS = isoparse("2018-05-02T01:56:00+00:00")
+HAPPY_TO_TS = isoparse("2018-05-03T01:56:00+00:00")
+
+# Functioning CSV for IROC. Has 6 lines, 5 different timestamps
+# (2018-05-02T06:44:29.7830000Z occurs twice) and 3 different tags.
+IROC_HAPPY_PATH_CSV = u"""tag,value,timestamp,status
+NINENINE.OPCIS::NNFCDPC01.AI1410J0,5,2018-05-02T06:00:11.3860000Z,Analog Normal
+NINENINE.OPCIS::NNFCDPC01.AI1410J0,76.86899,2018-05-02T06:44:29.7830000Z,Analog Normal
+NINENINE.OPCIS::NNFCDPC01.AI1840C1J0,-23.147645,2018-05-02T06:43:53.8490000Z,Analog Normal
+NINENINE.OPCIS::NNFCDPC01.AI1840C1J0,-10.518037,2018-05-02T06:44:29.9130000Z,Analog Normal
+NINENINE.OPCIS::NNFCDPC01.AI1840E1J0,48.92137,2018-05-02T06:43:59.7240000Z,Analog Normal
+NINENINE.OPCIS::NNFCDPC01.AI1840E1J0,-0.497645,2018-05-02T06:44:29.7830000Z,Analog Normal
+                """
+
+
+class IrocDataSourceTestCase(unittest.TestCase):
+    def test_read_iroc_file_basic(self):
+        """A basic happy-path testing of reading an iroc CSV with some values"""
+        f = StringIO(IROC_HAPPY_PATH_CSV)
+        res_df = read_iroc_file(
+            file_obj=f,
+            from_ts=HAPPY_FROM_TS,
+            to_ts=HAPPY_TO_TS,
+            tag_list=IROC_HAPPY_TAG_LIST,
+        )
+        for tag in IROC_HAPPY_TAG_LIST:
+            self.assertIn(tag, res_df.columns)
+        # We have one row per distinct timestamp in the input-csv
+        self.assertEqual(5, len(res_df))
+
+    def test_read_iroc_file_with_errors(self):
+        """Reading a csv with some of the 'values' beeing strings instead of numbers
+        leads to those lines being ignored completely"""
+        f = StringIO(
+            u"""tag,value,timestamp,status
+NINENINE.OPCIS::NNFCDPC01.AI1410J0,5,2018-05-02T06:00:11.3860000Z,Analog Normal
+NINENINE.OPCIS::NNFCDPC01.AI1410J0,76.86899,2018-05-02T06:44:29.7830000Z,Analog Normal
+NINENINE.OPCIS::NNFCDPC01.AI1840C1J0,lameness,2018-05-02T06:43:53.8490000Z,Analog Normal
+NINENINE.OPCIS::NNFCDPC01.AI1840C1J0,-10.518037,2018-05-02T06:44:29.9130000Z,Analog Normal
+NINENINE.OPCIS::NNFCDPC01.AI1840E1J0,wtf,2018-05-02T06:43:59.7240000Z,Analog Normal
+NINENINE.OPCIS::NNFCDPC01.AI1840E1J0,-0.497645,2018-05-02T06:44:29.7830000Z,Analog Normal
+                """
+        )
+        tags = IROC_HAPPY_TAG_LIST
+        res_df = read_iroc_file(
+            file_obj=f,
+            from_ts=isoparse("2018-05-02T01:56:00+00:00"),
+            to_ts=isoparse("2018-05-03T01:56:00+00:00"),
+            tag_list=tags,
+        )
+        for tag in tags:
+            self.assertIn(tag, res_df.columns)
+        # Two of the lines have invalid values (non-numeric), so those are ignored
+        # and there are only 3 distinct timestamps left.
+        self.assertEqual(3, len(res_df))
+
+    @mock.patch.object(
+        IrocReader,
+        "_fetch_all_iroc_files_from_paths",
+        side_effect=lambda all_base_paths, from_ts, to_ts, tag_list: [
+            read_iroc_file(
+                file_obj=StringIO(IROC_HAPPY_PATH_CSV),
+                from_ts=from_ts,
+                to_ts=to_ts,
+                tag_list=tag_list,
+            )
+        ],
+    )
+    def test_load_dataframes_no_data(self, _mocked_method):
+        """load_dataframe will raise ValueError if it does not find any tags"""
+        iroc_reader = IrocReader(client=None, threads=1)
+        with self.assertRaises(ValueError):
+            list(
+                iroc_reader.load_dataframes(
+                    from_ts=isoparse("2018-05-02T01:56:00+00:00"),
+                    to_ts=isoparse("2018-05-03T01:56:00+00:00"),
+                    tag_list=["jalla"],  # Not a tag in the input
+                )
+            )
+
+    @mock.patch.object(
+        IrocReader,
+        "_fetch_all_iroc_files_from_paths",
+        side_effect=lambda all_base_paths, from_ts, to_ts, tag_list: [
+            read_iroc_file(
+                file_obj=StringIO(IROC_HAPPY_PATH_CSV),
+                from_ts=from_ts,
+                to_ts=to_ts,
+                tag_list=tag_list,
+            )
+        ],
+    )
+    def test_load_dataframes_missing_columns_data(self, _mocked_method):
+        """load_dataframe will raise ValueError if there is a single tag it can not
+        find"""
+        iroc_reader = IrocReader(client=None, threads=1)
+        with self.assertRaises(ValueError):
+            list(
+                iroc_reader.load_dataframes(
+                    from_ts=isoparse("2018-05-02T01:56:00+00:00"),
+                    to_ts=isoparse("2018-05-03T01:56:00+00:00"),
+                    tag_list=IROC_HAPPY_TAG_LIST + ["jalla"],  # "jalla" is not a tag
+                )
+            )
+
+    @mock.patch.object(
+        IrocReader,
+        "_fetch_all_iroc_files_from_paths",
+        side_effect=lambda all_base_paths, from_ts, to_ts, tag_list: [
+            read_iroc_file(
+                file_obj=StringIO(IROC_HAPPY_PATH_CSV),
+                from_ts=from_ts,
+                to_ts=to_ts,
+                tag_list=tag_list,
+            )
+        ],
+    )
+    def test_load_dataframes_happy_path(self, _mocked_method):
+        """Happy-path testing of load_dataframe"""
+        iroc_reader = IrocReader(client=None, threads=1)
+        res = list(
+            iroc_reader.load_dataframes(
+                from_ts=isoparse("2018-05-02T01:56:00+00:00"),
+                to_ts=isoparse("2018-05-03T01:56:00+00:00"),
+                tag_list=IROC_HAPPY_TAG_LIST,
+            )
+        )
+        # We get one dataframe per tag, so 3
+        self.assertEqual(3, len(res))

--- a/tests/test_data_providers.py
+++ b/tests/test_data_providers.py
@@ -1,0 +1,84 @@
+import re
+import unittest
+from datetime import datetime
+from typing import Iterable, List, Pattern, Any
+
+import pandas as pd
+
+from gordo_components.data_provider.base import GordoBaseDataProvider
+from gordo_components.data_provider.providers import (
+    load_dataframes_from_multiple_providers,
+)
+
+
+class MockProducerRegExp(GordoBaseDataProvider):
+    def can_handle_tag(self, tag):
+        return self.regexp.match(tag)
+
+    def load_dataframes(
+        self, from_ts: datetime, to_ts: datetime, tag_list: List[str]
+    ) -> Iterable[pd.DataFrame]:
+        for tag in tag_list:
+            if self.regexp.match(tag):
+                yield pd.DataFrame(columns=[str(self.regexp.pattern)])
+            else:
+                raise ValueError(f"Unable to find base path from tag {tag}")
+
+    def __init__(self, regexp: Pattern[Any], **kwargs):
+        """
+        Mock producer which can handle tags which follow the regexp, and yields empty
+        dataframes with one column being the regexp pattern.
+
+        Parameters
+        ----------
+        regexp
+            Regular expression for tags the mock producer can accept
+        """
+        super().__init__(**kwargs)
+        self.regexp = regexp  # type: Pattern[Any]
+
+
+class LoadMultipleDataFramesTest(unittest.TestCase):
+    @classmethod
+    def setUp(self):
+        # Producer only accepting tags which starts with "ab"
+        self.ab_producer = MockProducerRegExp(re.compile("ab.*"))
+        # Producer only accepting tags which contain a "b"
+        self.containing_b_producer = MockProducerRegExp(re.compile(".*b.*"))
+
+    def test_load_multiple_raises_with_no_matches(self):
+        """If no provider matches a tag then load_dataframes_from_multiple_providers
+        raises a ValueError when the generator is realized"""
+        with self.assertRaises(ValueError):
+            list(
+                load_dataframes_from_multiple_providers(
+                    [self.ab_producer, self.containing_b_producer],
+                    None,
+                    None,
+                    ["ab", "tag_not_matching_any_of_the_regexps"],
+                )
+            )
+
+    def test_load_multiple_matches_loads_from_first(self):
+        """When a tag can be read from multiple providers it is the first provider in
+        the list of providers which gets the job"""
+        dfs = list(
+            load_dataframes_from_multiple_providers(
+                [self.ab_producer, self.containing_b_producer], None, None, ["abba"]
+            )
+        )
+        self.assertEqual(dfs[0].columns[0], "ab.*")
+
+    def test_load_from_multiple_providers(self):
+        """ Two tags, each belonging to different data producers, and both gets loaded
+        """
+        dfs = list(
+            load_dataframes_from_multiple_providers(
+                [self.ab_producer, self.containing_b_producer],
+                None,
+                None,
+                ["abba", "cba"],
+            )
+        )
+        self.assertEqual(dfs[0].columns[0], "ab.*")
+        self.assertEqual(dfs[1].columns[0], ".*b.*")


### PR DESCRIPTION
Added ability to download IROC data with the DataLakeProvider. In the process I created two "new" dataproviders, NcsReader (Norwegian Continental Shelf, extracted from the old DataLakeProvider) and IrocReader. I created the baseclass `GordoAwareDataProvider` for data-providers which are aware of what tags they can download (Influx is an example of a non-aware dataprovider, so far at least). `DataLakeProvider` now creates an instance of both NcsReader and IrocReader, and then delegates the downloading to whoever claims it can handle it. 

The IROC downloader uses 50 threads by default, for no particular reason.

Both the IROC reader and NcsReader could/should(?) be renamed to providers, since they now are exactly that. But they are also kind of not intended to be used directly, but they can.