### PR TITLE
Fast quit IROC reader on empty tag-list

### DIFF
--- a/gordo_components/data_provider/iroc_reader.py
+++ b/gordo_components/data_provider/iroc_reader.py
@@ -40,6 +40,14 @@ class IrocReader(GordoBaseDataProvider):
         See GordoBaseDataProvider for documentation
         """
 
+        if not tag_list:
+            logger.warning("Iroc reader called with empty tag_list, returning none")
+            return
+        if to_ts < from_ts:
+            raise ValueError(
+                f"Iroc reader called with to_ts: {to_ts} before from_ts: {from_ts}"
+            )
+
         base_path = base_path.strip("/")
 
         # We query with an extra day on both sides since the way the files are

--- a/gordo_components/data_provider/ncs_reader.py
+++ b/gordo_components/data_provider/ncs_reader.py
@@ -55,6 +55,10 @@ class NcsReader(GordoBaseDataProvider):
         """
         See GordoBaseDataProvider for documentation
         """
+        if to_ts < from_ts:
+            raise ValueError(
+                f"NCS reader called with to_ts: {to_ts} before from_ts: {from_ts}"
+            )
         adls_file_system_client = self.client
 
         years = range(from_ts.year, to_ts.year + 1)

--- a/tests/test_data_provider_iroc.py
+++ b/tests/test_data_provider_iroc.py
@@ -92,6 +92,30 @@ NINENINE.OPCIS::NNFCDPC01.AI1840E1J0,-0.497645,2018-05-02T06:44:29.7830000Z,Anal
                 )
             )
 
+    def test_load_dataframes_no_tag_list(self):
+        """load_dataframe will return an empty generator when called with no tags"""
+        iroc_reader = IrocReader(client=None, threads=1)
+        res = list(
+            iroc_reader.load_dataframes(
+                from_ts=isoparse("2018-05-02T01:56:00+00:00"),
+                to_ts=isoparse("2018-05-03T01:56:00+00:00"),
+                tag_list=[],
+            )
+        )
+        self.assertEqual([], res)
+
+    def test_load_dataframes_checks_date(self):
+        """load_dataframe will raise ValueError if to_ts<from_ts"""
+        iroc_reader = IrocReader(client=None, threads=1)
+        with self.assertRaises(ValueError):
+            list(
+                iroc_reader.load_dataframes(
+                    from_ts=isoparse("2018-05-03T01:56:00+00:00"),
+                    to_ts=isoparse("2018-05-02T01:56:00+00:00"),
+                    tag_list=["jalla"],  # Not a tag in the input
+                )
+            )
+
     @mock.patch.object(
         IrocReader,
         "_fetch_all_iroc_files_from_paths",


### PR DESCRIPTION
Earlier the IROC reader started crawling the whole file-system
looking for no tags.

This closes #149.