### PR TITLE
Add helper CLI commands for ArgoCD & Cluster login steps

### DIFF
--- a/gordo_components/cli/__init__.py
+++ b/gordo_components/cli/__init__.py
@@ -1,0 +1,1 @@
+from .cli import mgmt, gordo

--- a/gordo_components/cli/cli.py
+++ b/gordo_components/cli/cli.py
@@ -19,6 +19,7 @@ from gordo_components.data_provider.providers import (
 )
 from gordo_components.server import server
 from gordo_components import watchman
+from gordo_components.cli import mgmt
 
 import dateutil.parser
 
@@ -139,6 +140,9 @@ def run_server_cli(
     src_influx_api_key: str,
     src_influx_api_key_header: str,
 ):
+    """
+    Run the ML Server
+    """
 
     # We have have a hostname, then we make a data provider
     if src_influx_host:
@@ -193,6 +197,9 @@ def run_watchman_cli(project_name, target_names, host, port, debug):
 gordo.add_command(build)
 gordo.add_command(run_server_cli)
 gordo.add_command(run_watchman_cli)
+gordo.add_command(mgmt.cluster)
+gordo.add_command(mgmt.argocd)
+
 
 if __name__ == "__main__":
     gordo()

--- a/gordo_components/cli/mgmt/__init__.py
+++ b/gordo_components/cli/mgmt/__init__.py
@@ -1,0 +1,2 @@
+from .cluster_mgmt import cluster
+from .argocd_mgmt import argocd

--- a/gordo_components/cli/mgmt/argocd_mgmt.py
+++ b/gordo_components/cli/mgmt/argocd_mgmt.py
@@ -1,0 +1,246 @@
+# -*- coding: utf-8 -*-
+
+import click
+import sys
+import subprocess
+import json
+
+from .helpers import _azure_cli_exists
+
+
+@click.group("argocd")
+def argocd():
+    """
+    Subcommand for ArgoCD releated activites
+    """
+    pass
+
+
+@click.command("login")
+@click.option(
+    "--host",
+    type=str,
+    prompt="ArgoCD host, ie. 'grpc.auroracicd06.omnia-aurora-equinor.net'",
+)
+@click.option(
+    "--keyvault-name", type=str, prompt="Keyvault name which holds the password"
+)
+@click.option(
+    "--secret-name", type=str, prompt="Secret name for password held in keyvault"
+)
+@click.option("--username", type=str, prompt="Username", default="admin")
+def argocd_login_cli(host: str, secret_name: str, keyvault_name: str, username: str):
+    """
+    \b
+    Log into an ArgoCD resource
+
+    \f
+    Example
+    -------
+    gordo-components argocd login
+
+    \b
+    Parameters
+    ----------
+    host: str
+        Host to login to
+    secret_name: str
+        Name of the secret to extract from the keyvault
+    keyvault_name: str
+        Name of the keyvault to look for the secret
+    username: str
+        Username to login with.
+
+    Returns
+    -------
+    None
+    """
+    if not _azure_cli_exists():
+        sys.exit(1)
+
+    # Get the password
+    cmd = f"az keyvault secret show --name {secret_name} --vault-name {keyvault_name}".split()
+
+    try:
+        result = subprocess.check_output(cmd, stderr=subprocess.PIPE)
+    except subprocess.CalledProcessError as err:
+        click.secho(f"\u23F0 Failed to get password: {err.stderr}", fg="red")
+        sys.exit(1)
+
+    password = json.loads(result.decode("utf-8"))["value"]
+
+    cmd = f"argocd login {host} --password {password} --username {username} --insecure".split()
+    try:
+        subprocess.check_output(cmd, stderr=subprocess.PIPE)
+    except subprocess.CalledProcessError as err:
+        click.secho(f" \u23F0 Failed to login -> {err.stderr} ", fg="red")
+        sys.exit(1)
+    else:
+        click.secho(f"\U0001F389 Logged into ArgoCD on {host}!")
+
+
+@click.command("clusters")
+def argocd_list_clusters_cli():
+    """
+    List available clusters to the current ArgoCD context
+    """
+    try:
+        result = subprocess.check_output(
+            "argocd cluster list".split(), stderr=subprocess.PIPE
+        )
+    except subprocess.CalledProcessError as err:
+        click.secho(f"Failed to list clusters: {err.stderr}")
+    else:
+        click.secho(f'List of available clusters: \n{"-" * 40}')
+        click.secho(result.decode(), fg="green")
+
+
+@click.group("add")
+def argocd_add_cli_group():
+    """
+    Subcommand for adding a repo or app to ArgoCD
+    """
+    pass
+
+
+@click.command("repo")
+@click.option(
+    "--git-url",
+    type=str,
+    prompt='SSH git url to repo, ie "git@github.com:equinor/my-project.git',
+)
+@click.option(
+    "--ssh-private-key",
+    type=click.Path(exists=True, dir_okay=False),
+    prompt="Path to the private key associated with this repo",
+)
+def argocd_add_repo_cli(git_url: str, ssh_private_key: str):
+    """
+    Add a repo to ArgoCD
+
+    \b
+    Parameters
+    ----------
+    git_url: str
+        The ssh styled git url. ie. git@github.com:equinor/my-project.git
+    ssh_private_key: str
+        The path to the private ssh key associated with this repo
+    """
+    if not _azure_cli_exists():
+        sys.exit(1)
+
+    cmd = f"argocd repo add {git_url} --ssh-private-key-path {ssh_private_key}".split()
+    try:
+        subprocess.check_output(cmd, stderr=subprocess.PIPE)
+    except subprocess.CalledProcessError as err:
+        click.secho(f"\u23F0  Failed to add repo: {err.stderr}")
+        sys.exit(1)
+    else:
+        click.secho(f"\U0001F680 Added repo!")
+
+
+@click.command("app")
+@click.option("--name", prompt="Name to give this application on ArgoCD", type=str)
+@click.option(
+    "--git-url",
+    prompt='SSH git url to repo, ie "git@github.com:equinor/my-project.git" for app',
+    type=str,
+)
+@click.option(
+    "--auto-sync", is_flag=True, prompt="Do you want to enable auto sync?", default=True
+)
+@click.option(
+    "--namespace", prompt="The namespace to launch this app into", default="kubeflow"
+)
+@click.option(
+    "--destination-server",
+    prompt="""The desintation cluster to launch applications into 
+    see "gordo-components argocd clusters" for a list of available clusters/servers. 
+    This should include the "https:// and port" prefix""",
+    type=str,
+)
+@click.option(
+    "--path",
+    prompt="The path of the app within the repo, if not top level",
+    default="kubernetes-deployment",
+)
+@click.option(
+    "--env", default="default", prompt="The app environment to use when launching."
+)
+@click.option(
+    "--force",
+    default=False,
+    is_flag=True,
+    prompt="Force an application update, helpful if changing an app's"
+    " parameter such as its destination cluster",
+)
+def argocd_add_app_cli(
+    name: str,
+    git_url: str,
+    auto_sync: bool,
+    namespace: str,
+    destination_server: str,
+    path: str,
+    env: str,
+    force: bool,
+):
+    """
+    Add an application to ArgoCD
+
+    \b
+    Example
+    -------
+    gordo-components argocd add app
+
+    \b
+    Parameters
+    ----------
+    name: str
+        Name of the application you want to give as reference in ArgoCD
+    git_url:
+        The url got your git repo for this project
+    auto_sync: bool
+        Auto sync will automatically sync the application after changes are
+        detected in the git repo
+    namespace: str
+        Namespace in Kubernetes to deploy application to
+    destination_server: str
+        The base url of the desintation server. ie https://my-cluster:443
+    path: str
+        If the application cannot be auto detected, for example if it's within
+        a nested directory of your repo, you can specify the repo path to it.
+    env: str
+        If your application has different environments, you can specify it here,
+        default is 'default'
+
+    """
+    cmd = (
+        f"argocd app create {name} --repo {git_url} --dest-namespace {namespace} "
+        f"--dest-server {destination_server} --env {env}".split()
+    )
+
+    if path:
+        cmd += f"--path {path}".split()
+    if auto_sync:
+        cmd += f"--sync-policy automated".split()
+    if force:
+        cmd += ["--upsert"]
+
+    try:
+        subprocess.check_output(cmd, stderr=subprocess.PIPE)
+    except subprocess.CalledProcessError as err:
+        click.secho(f"\u23F0 Failed to add application: {err.stderr}", fg="red")
+        sys.exit(1)
+    else:
+        click.secho(f"\U0001F389 Added application '{name}'!")
+
+
+argocd.add_command(argocd_login_cli)
+argocd.add_command(argocd_list_clusters_cli)
+
+# Subcommand of 'argocd'
+argocd.add_command(argocd_add_cli_group)
+
+# Subcommands of 'argocd add'
+argocd_add_cli_group.add_command(argocd_add_repo_cli)
+argocd_add_cli_group.add_command(argocd_add_app_cli)

--- a/gordo_components/cli/mgmt/cluster_mgmt.py
+++ b/gordo_components/cli/mgmt/cluster_mgmt.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+
+import click
+import sys
+import subprocess
+
+from .helpers import _azure_cli_exists
+
+
+@click.group("cluster")
+def cluster():
+    """
+    Set of helpful cluster commands relating for Gordo
+    """
+    pass
+
+
+@click.command("login")
+@click.option("--name", type=str, prompt="Name of cluster to login to")
+@click.option("--admin", prompt="Login as admin?", default=True, is_flag=True)
+def cluster_login_cli(name: str, admin: bool):
+    """
+    Sign into a cluster.
+
+    \b
+    Example: "gordo-components cluster login"
+
+    \b
+    Parameters
+    ----------
+    name: str
+        Name of cluster to login into, expected the name and resource group name
+        are the same
+    admin: bool
+        Whether login should be as administrator or not.
+    \b
+    Returns
+    -------
+    None
+    """
+    if not _azure_cli_exists():
+        sys.exit(1)
+
+    cmd = ["az", "aks", "get-credentials", "--resource-group", name, "--name", name]
+    if admin:
+        cmd.append("--admin")
+
+    try:
+        subprocess.check_output(cmd, stderr=subprocess.PIPE)
+    except subprocess.CalledProcessError as err:
+        click.secho(f" \u23F0 Failed to login: {err.stderr}", fg="red")
+    else:
+        click.secho(f"\U0001F680 Successful login for: '{name}'")
+
+
+cluster.add_command(cluster_login_cli)

--- a/gordo_components/cli/mgmt/helpers.py
+++ b/gordo_components/cli/mgmt/helpers.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+
+import subprocess
+import click
+
+
+def _azure_cli_exists() -> bool:
+    try:
+        subprocess.check_output(["az", "--version"], stderr=subprocess.PIPE)
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        click.secho(
+            f"\u23F0  Failed to find azure CLI install in current environment. "
+            f"Running 'pip install azure-cli' may fix this.",
+            fg="red",
+        )
+        return False
+    else:
+        click.secho("\U0001F382 Found install of Azure CLI", fg="green")
+        return True


### PR DESCRIPTION
Will close #157 

With this one can go through **prompted** steps to:

- Authenticate with a new cluster `gordo-components cluster login`
- Authenticate with a new argocd resource `gordo-components argocd login`
- Add a repo to ArgoCD `gordo-components argocd add repo`
- Add or update app for ArgoCD `gordo-components argocd add app`
- See available clusters available to ArgoCD `gordo-components argocd clusters`

All take optional arguments but will default to terminal prompts and examples of valid input

...did I mention the happy emojis?