### PR TITLE
Add coverage/coveralls reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ jobs:
     install:
       - pip install -r requirements.txt
     script:
-      - python setup.py testall
+      - make coverage
   - name: "make images"
     install: skip
     script:

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,10 @@ images: model-builder model-server watchman
 test:
 	python setup.py test
 
+coverage:
+	coverage run --source=gordo_components setup.py testall
+	coverage report -m
+
 docs:
 	cd ./docs && $(MAKE) html
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ cffi==1.12.2              # via azure-datalake-store, cryptography
 chardet==3.0.4            # via requests
 click==7.0
 commonmark==0.8.1         # via recommonmark
+coverage==4.5.3
 cryptography==2.6.1       # via adal
 docutils==0.14            # via recommonmark, sphinx
 flask-restplus==0.12.1

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ install_requires = [
     "sphinx~=1.8",
     "recommonmark~=0.5.0",
     "sphinx-click~=2.0",
+    "coverage~=4.5",
 ]
 
 setup_requirements = ["pytest-runner", "setuptools_scm"]


### PR DESCRIPTION
Part of #156 
Not enabled for Coveralls.io reporting, until we're open sourced. Will print out the coverage report at the end of the tests right now. We're at... **86%**! 