### PR TITLE
Set default azure log level to INFO

### DIFF
--- a/gordo_components/cli.py
+++ b/gordo_components/cli.py
@@ -24,11 +24,14 @@ import dateutil.parser
 
 # Set log level, defaulting to DEBUG
 log_level = os.getenv("LOG_LEVEL", "DEBUG").upper()
+azure_log_level = os.getenv("AZURE_DATALAKE_LOG_LEVEL", "INFO").upper()
+
 logging.basicConfig(
     level=getattr(logging, log_level),
     format="[%(asctime)s] %(levelname)s [%(name)s.%(funcName)s:%(lineno)d] %(message)s",
 )
 logger = logging.getLogger(__name__)
+logging.getLogger("azure.datalake").setLevel(azure_log_level)
 
 
 @click.group("gordo-components")


### PR DESCRIPTION
Introduce new environment variable AZURE_DATALAKE_LOG_LEVEL which
sets the log level for the azure datalake, and default it to INFO.

This closes #168