### PR TITLE
Model caching

### DIFF
--- a/gordo_components/builder/build_model.py
+++ b/gordo_components/builder/build_model.py
@@ -1,20 +1,22 @@
 # -*- coding: utf-8 -*-
-
-import os
-import logging
 import datetime
+import hashlib
+import json
+import logging
+import os
 import time
+from pathlib import Path
+from typing import Union, Optional
 
-from typing import Union
 from sklearn.base import BaseEstimator
-from sklearn.pipeline import Pipeline
 from sklearn.model_selection import cross_val_score, TimeSeriesSplit
+from sklearn.pipeline import Pipeline
 
+from gordo_components.util import disk_registry
 from gordo_components import serializer, __version__
 from gordo_components.dataset import _get_dataset
 from gordo_components.dataset.base import GordoBaseDataset
 from gordo_components.model.base import GordoBase
-
 
 logger = logging.getLogger(__name__)
 
@@ -106,7 +108,9 @@ def build_model(
     return model, metadata
 
 
-def _save_model_for_workflow(model: BaseEstimator, metadata: dict, output_dir: str):
+def _save_model_for_workflow(
+    model: BaseEstimator, metadata: dict, output_dir: Union[os.PathLike, str]
+):
     """
     Save a model according to the expected Argo workflow procedure.
 
@@ -116,19 +120,17 @@ def _save_model_for_workflow(model: BaseEstimator, metadata: dict, output_dir: s
         The model to save to the directory with gordo serializer.
     metadata: dict
         Various mappings of metadata to save alongside model.
-    output_dir: str
+    output_dir: Union[os.PathLike, str]
         The directory where to save the model, will create directories if needed.
 
     Returns
     -------
-    None
+    Union[os.PathLike, str]
+        Path to the saved model
     """
     os.makedirs(output_dir, exist_ok=True)  # Ok if some dirs exist
     serializer.dump(model, output_dir, metadata=metadata)
-
-    # Let argo & subsequent model loader know where the model will be saved.
-    with open("/tmp/model-location.txt", "w") as f:
-        f.write(output_dir)
+    return output_dir
 
 
 def _get_final_gordo_base_step(model: BaseEstimator):
@@ -156,3 +158,143 @@ def _get_final_gordo_base_step(model: BaseEstimator):
 
     else:
         return None
+
+
+def calculate_model_key(
+    model_config: dict, data_config: dict, metadata: Optional[dict] = None
+) -> str:
+    """
+    Calculates a hash-key from a model and data-config.
+
+    Notes
+    -----
+    Ignores the data_provider key since this is an complicated object.
+
+    Parameters
+    ----------
+    model_config: dict
+        Config for the model. See
+        :func:`gordo_components.builder.build_model.build_model`.
+    data_config: dict
+        Config for the data-configuration. See
+        :func:`gordo_components.builder.build_model.build_model`.
+    metadata: Optional[dict] = None
+        Metadata for the models. See
+        :func:`gordo_components.builder.build_model.build_model`.
+
+    Returns
+    -------
+    str:
+        A 512 byte hex value as a string based on the content of the parameters.
+
+    Examples
+    -------
+    >>> len(calculate_model_key(model_config={"model": "something"},
+    ... data_config={"tag_list": ["tag1", "tag 2"]} ))
+    128
+    """
+    if metadata is None:
+        metadata = {}
+    # TODO Fix this when we get a good way of passing data_provider in the yaml/json
+    if "data_provider" in data_config:
+        logger.warning(
+            "data_provider key found in data_config, ignoring it when creating hash"
+        )
+        data_config = dict(data_config)
+        del data_config["data_provider"]
+
+    # Sets a lot of the parameters to json.dumps explicitly to ensure that we get
+    # consistent hash-values even if json.dumps changes their default values (and as such might
+    # generate different json which again gives different hash)
+    json_rep = json.dumps(
+        {
+            "model_config": model_config,
+            "data_config": data_config,
+            "user-defined": metadata,
+        },
+        sort_keys=True,
+        default=str,
+        skipkeys=False,
+        ensure_ascii=True,
+        check_circular=True,
+        allow_nan=True,
+        cls=None,
+        indent=None,
+        separators=None,
+    )
+    return hashlib.sha3_512(json_rep.encode("ascii")).hexdigest()
+
+
+def provide_saved_model(
+    model_config: dict,
+    data_config: dict,
+    metadata: dict,
+    output_dir: Union[os.PathLike, str],
+    model_register_dir: Union[os.PathLike, str] = None,
+) -> Union[os.PathLike, str]:
+    """
+    Ensures that the desired model exists on disk, and returns the path to it.
+
+    Builds the model if needed, or finds it among already existing models if
+    ``model_register_dir`` is non-None, and we find the model there. If
+    `model_register_dir` is set we will also store the model-location of the generated
+    model there for future use. Think about it as a cache that is never emptied.
+
+    Parameters
+    ----------
+    model_config: dict
+        Config for the model. See
+        :func:`gordo_components.builder.build_model.build_model`.
+    data_config: dict
+        Config for the data-configuration. See
+        :func:`gordo_components.builder.build_model.build_model`.
+    metadata: dict
+        Extra metadata to be added to the built models if it is built. See
+        :func:`gordo_components.builder.build_model.build_model`.
+    output_dir: Union[os.PathLike, str]
+        A path to where the model will be deposited if it is built.
+    model_register_dir:
+        A path to a register, see `gordo_components.util.disk_registry`. If this is None
+        then always build the model, otherwise try to resolve the model from the
+        registry.
+
+    Returns
+    -------
+    os.PathLike:
+        Path to the model
+    """
+    cache_key = calculate_model_key(model_config, data_config, metadata=metadata)
+    if model_register_dir:
+        logger.info(
+            f"Model caching activated, attempting to read model-location with key "
+            f"{cache_key} from register {model_register_dir}"
+        )
+        existing_model_location = disk_registry.get_value(model_register_dir, cache_key)
+
+        # Check that the model is actually there
+        if existing_model_location and Path(existing_model_location).exists():
+            logger.debug(
+                f"Found existing model at path {existing_model_location}, returning it"
+            )
+            return existing_model_location
+        elif existing_model_location:
+            logger.warning(
+                f"Found that the model-path {existing_model_location} stored in the "
+                f"registry did not exist."
+            )
+        else:
+            logger.info(
+                f"Did not find the model with key {cache_key} in the register at "
+                f"{model_register_dir}."
+            )
+    model, metadata = build_model(
+        model_config=model_config, data_config=data_config, metadata=metadata
+    )
+    model_location = _save_model_for_workflow(
+        model=model, metadata=metadata, output_dir=output_dir
+    )
+    logger.info(f"Successfully built model, and deposited at {model_location}")
+    if model_register_dir:
+        logger.info(f"Writing model-location to model registry")
+        disk_registry.write_key(model_register_dir, cache_key, model_location)
+    return model_location

--- a/gordo_components/serializer/serializer.py
+++ b/gordo_components/serializer/serializer.py
@@ -245,7 +245,7 @@ def _load_step(source_dir: str) -> Tuple[str, object]:
             return step_name, pickle.load(f)
 
 
-def dump(obj: object, dest_dir: str, metadata: dict = None):
+def dump(obj: object, dest_dir: Union[os.PathLike, str], metadata: dict = None):
     """
     Serialize an object into a directory
 
@@ -259,10 +259,12 @@ def dump(obj: object, dest_dir: str, metadata: dict = None):
     obj
         The object to dump. Must be picklable or implement
         a ``save_to_dir`` AND ``load_from_dir`` method.
-    dest_dir
+    dest_dir: Union[os.PathLike, str]
         The directory to which to save the model metadata: dict - any additional
         metadata to be saved alongside this model if it exists, will be returned
         from the corresponding "load" function
+    metadata: Optional dict of metadata which will be serialized to a file together
+        with the model, and loaded again by :func:`load_metadata`.
 
     Returns
     -------
@@ -292,7 +294,9 @@ def dump(obj: object, dest_dir: str, metadata: dict = None):
 
 
 def _dump_step(
-    step: Tuple[str, Union[GordoBase, TransformerMixin]], dest_dir: str, n_step: int = 0
+    step: Tuple[str, Union[GordoBase, TransformerMixin]],
+    dest_dir: Union[os.PathLike, str],
+    n_step: int = 0,
 ):
     """
     Accepts any Scikit-Learn transformer and dumps it into a directory

--- a/gordo_components/util/__init__.py
+++ b/gordo_components/util/__init__.py
@@ -1,0 +1,1 @@
+from .disk_registry import get_value, write_key

--- a/gordo_components/util/disk_registry.py
+++ b/gordo_components/util/disk_registry.py
@@ -1,0 +1,84 @@
+import os
+from pathlib import Path
+from typing import Union, AnyStr, Optional
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+"""
+A simple file-based key/value registry. Each key gets a file with filename = key, and
+the content of the file is the value. No fancy. Why? Simple, and there is no problems
+with concurrent writes to different keys. Concurrent writes to the same key will break 
+stuff. 
+"""
+
+
+def write_key(registry_dir: Union[os.PathLike, str], key: str, val: AnyStr):
+    """ Registers a key-value combination into the register. Key must valid as a
+    filename.
+
+    Parameters
+    ----------
+    registry_dir: Union[os.PathLike, str]
+        Path to the registry. If it does not exists it will be created, including any
+        missing folders in the path.
+    key: str
+        Key to use for the key/value. Must be valid as a filename.
+    val: AnyStr
+        Value to write to the registry.
+
+    Examples
+    --------
+    In the following example we use the temp directory as the registry
+    >>> import tempfile
+    >>> with tempfile.TemporaryDirectory() as tmpdir:
+    ...     write_key(tmpdir, "akey", "aval")
+    ...     get_value(tmpdir, "akey")
+    'aval'
+    """
+    key_file_path = Path(registry_dir).joinpath(key)
+    logger.info(f"Storing object with key {key} to {key_file_path}")
+    # If the model location already exists in the cache we overwrite it
+    if key_file_path.exists():
+        logger.warning(f"Key {key} already exists, " f"overwriting")
+    elif not Path(registry_dir).exists():
+        logger.debug(
+            f"Found that registry dir {registry_dir} does not exists, creating it"
+        )
+        # If someone else creates the directory at the same time we accept that by
+        # exists_ok=True
+        os.makedirs(registry_dir, exist_ok=True)
+    with key_file_path.open(mode="w") as f:
+        f.write(val)
+
+
+def get_value(registry_dir: Union[os.PathLike, str], key: str) -> Optional[AnyStr]:
+    """
+    Retrieves the value with key `reg_key`from the registry, None if it does not
+    exists.
+
+    Parameters
+    ----------
+    registry_dir: Union[os.PathLike, str]
+        Path to the registry. If it does not exist we return None
+    key: str
+        Key to look up in the registry.
+
+    Returns
+    -------
+    Optional[AnyStr]
+        The value of `key` in the registry, None if no value is registered with that key
+        in the registry.
+    """
+    output_val = None
+    key_file_path = Path(registry_dir).joinpath(key)
+    logger.info(f"Looking for registry key {key} at path " f"{key_file_path}")
+    # If the model location exists
+    if key_file_path.exists():
+        with key_file_path.open(mode="r") as f:
+            output_val = f.read()
+        logger.debug(f"Read value {output_val} from registry")
+    else:
+        logger.info(f"Did not find registry key {key} at path {key_file_path}")
+    return output_val

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,6 +12,18 @@ from tests.utils import temp_env_vars
 
 import json
 
+DATA_CONFIG = (
+    "{"
+    ' "type": "RandomDataset",'
+    ' "train_start_date": "2015-01-01T00:00:00+00:00", '
+    ' "train_end_date": "2015-06-01T00:00:00+00:00",'
+    ' "tags": ["tag1", "tag2"]'
+    "}"
+)
+
+MODEL_CONFIG = {
+    "gordo_components.model.models.KerasAutoEncoder": {"kind": "feedforward_hourglass"}
+}
 
 logger = logging.getLogger(__name__)
 
@@ -26,24 +38,17 @@ class CliTestCase(unittest.TestCase):
 
     def test_build_env_args(self):
         """
-        Instead of passing OUTPUT_DIR directly to CLI, should be able to 
+        Instead of passing OUTPUT_DIR directly to CLI, should be able to
         read environment variables
         """
 
-        model_config = {
-            "gordo_components.model.models.KerasAutoEncoder": {
-                "kind": "feedforward_hourglass"
-            }
-        }
-
-        logger.info(f"MODEL_CONFIG={json.dumps(model_config)}")
+        logger.info(f"MODEL_CONFIG={json.dumps(MODEL_CONFIG)}")
 
         with tempfile.TemporaryDirectory() as tmpdir:
             with temp_env_vars(
                 OUTPUT_DIR=tmpdir,
-                DATA_CONFIG='{"type": "RandomDataset", "train_start_date": "2015-01-01T00:00:00+00:00",'
-                ' "train_end_date": "2015-06-01T00:00:00+00:00", "tags": ["tag1", "tag2"]}',
-                MODEL_CONFIG=json.dumps(model_config),
+                DATA_CONFIG=DATA_CONFIG,
+                MODEL_CONFIG=json.dumps(MODEL_CONFIG),
             ):
                 result = self.runner.invoke(cli.gordo, ["build"])
 
@@ -52,3 +57,74 @@ class CliTestCase(unittest.TestCase):
                 os.path.exists("/tmp/model-location.txt"),
                 msg='Building was supposed to create a "model-location.txt", but it did not!',
             )
+
+    def test_build_use_registry(self):
+        """
+        Using a registry causes the second build of a model to return the path to the
+        first.
+        """
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with temp_env_vars(
+                OUTPUT_DIR=os.path.join(tmpdir, "dir1"),
+                DATA_CONFIG=DATA_CONFIG,
+                MODEL_CONFIG=json.dumps(MODEL_CONFIG),
+                MODEL_REGISTER_DIR=tmpdir + "/reg",
+            ):
+                result1 = self.runner.invoke(cli.gordo, ["build"])
+
+            self.assertEqual(result1.exit_code, 0, msg=f"Command failed: {result1}")
+            with open("/tmp/model-location.txt") as f:
+                first_path = f.read()
+
+            # OUTPUT_DIR is the only difference
+            with temp_env_vars(
+                OUTPUT_DIR=os.path.join(tmpdir, "dir2"),
+                DATA_CONFIG=DATA_CONFIG,
+                MODEL_CONFIG=json.dumps(MODEL_CONFIG),
+                MODEL_REGISTER_DIR=tmpdir + "/reg",
+            ):
+                result2 = self.runner.invoke(cli.gordo, ["build"])
+            self.assertEqual(result2.exit_code, 0, msg=f"Command failed: {result2}")
+            with open("/tmp/model-location.txt") as f:
+                second_path = f.read()
+            assert first_path == second_path
+
+    def test_build_use_registry_bust_cache(self):
+        """
+        Even using a registry we get separate model-paths when we ask for models for
+        different configurations.
+        """
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with temp_env_vars(
+                OUTPUT_DIR=os.path.join(tmpdir, "dir1"),
+                DATA_CONFIG=DATA_CONFIG,
+                MODEL_CONFIG=json.dumps(MODEL_CONFIG),
+                MODEL_REGISTER_DIR=tmpdir + "/reg",
+            ):
+                result1 = self.runner.invoke(cli.gordo, ["build"])
+
+            self.assertEqual(result1.exit_code, 0, msg=f"Command failed: {result1}")
+            with open("/tmp/model-location.txt") as f:
+                first_path = f.read()
+
+            with temp_env_vars(
+                OUTPUT_DIR=os.path.join(tmpdir, "dir2"),
+                # NOTE: Different train dates!
+                DATA_CONFIG=(
+                    "{"
+                    ' "type": "RandomDataset",'
+                    ' "train_start_date": "2019-01-01T00:00:00+00:00", '
+                    ' "train_end_date": "2019-06-01T00:00:00+00:00",'
+                    ' "tags": ["tag1", "tag2"]'
+                    "}"
+                ),
+                MODEL_CONFIG=json.dumps(MODEL_CONFIG),
+                MODEL_REGISTER_DIR=tmpdir + "/reg",
+            ):
+                result2 = self.runner.invoke(cli.gordo, ["build"])
+            self.assertEqual(result2.exit_code, 0, msg=f"Command failed: {result2}")
+            with open("/tmp/model-location.txt") as f:
+                second_path = f.read()
+            assert first_path != second_path

--- a/tests/test_disk_registry.py
+++ b/tests/test_disk_registry.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+
+import tempfile
+import pathlib
+
+from gordo_components.util import disk_registry
+
+
+def test_simple_happy_path():
+    """Tests that it works to write and read a simple value to a fresh registry"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        disk_registry.write_key(tmpdir, "akey", "aval")
+        assert disk_registry.get_value(tmpdir, "akey") == "aval"
+
+
+def test_new_registry():
+    """Tests that it works to write and read a simple value to a fresh registry with
+     a non-existing directory"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        registry = pathlib.Path(tmpdir).joinpath("newregistry")
+        disk_registry.write_key(registry, "akey", "aval")
+        assert disk_registry.get_value(registry, "akey") == "aval"
+
+
+def test_complicated_happy_path():
+    """Tests that it works to write and read a 'complicated' value"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        value = """
+        A long
+        value with many weird character lie åøæ
+        and some linebreaks"""
+        disk_registry.write_key(tmpdir, "akey", value)
+        assert disk_registry.get_value(tmpdir, "akey") == value
+
+
+def test_overwrites_existing():
+    """Double writes to the same registry overwrites the first value"""
+    the_key = "akey"
+    with tempfile.TemporaryDirectory() as tmpdir:
+        first_value = "Some value"
+        disk_registry.write_key(tmpdir, the_key, first_value)
+        assert disk_registry.get_value(tmpdir, the_key) == first_value
+        second_value = "Some value"
+        disk_registry.write_key(tmpdir, the_key, second_value)
+        assert disk_registry.get_value(tmpdir, the_key) == second_value


### PR DESCRIPTION
Optionally register and re-use old models

By using the --model-register-dir option to the build command you specify a
location for the model registry. This is not where the models are stored, but
the location of the registry. The registry contains the mapping from models to
their actual location.

This closes #179 