### PR TITLE
Bump notebook 5.7.4 to  5.7.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ test_requirements = [
     "pytest-flakes~=4.0",
     "adal~=1.2",
     "jupyter==1.0.0",
-    "notebook==5.7.4",
+    "notebook==5.7.8",
     "nbconvert==5.4.0",
     "tornado>=4, <6",  # https://github.com/jupyter/notebook/pull/4310#issuecomment-452368841
 ]


### PR DESCRIPTION
Will address the security vulnerability warning: 
- https://github.com/equinor/gordo-components/network/alert/setup.py/notebook/open
- https://nvd.nist.gov/vuln/detail/CVE-2019-10255