### PR TITLE
Fix external missing swagger

### DIFF
--- a/gordo_components/server/server.py
+++ b/gordo_components/server/server.py
@@ -12,8 +12,8 @@ from datetime import datetime
 import numpy as np
 import pandas as pd
 
-from flask import Flask, request, send_file, g
-from flask_restplus import Resource, fields, Api
+from flask import Flask, request, send_file, g, url_for
+from flask_restplus import Resource, fields, Api as BaseApi
 
 from gordo_components import __version__, serializer
 from gordo_components.dataset.datasets import TimeSeriesDataset
@@ -26,6 +26,13 @@ logger = logging.getLogger(__name__)
 MODEL_LOCATION_ENV_VAR = "MODEL_LOCATION"
 MODEL = None
 MODEL_METADATA = None
+
+
+class Api(BaseApi):
+    @property
+    def specs_url(self):
+        return url_for(self.endpoint("specs"), _external=False)
+
 
 api = Api(
     title="Gordo API Docs",


### PR DESCRIPTION
Will close #177 

Default behavior of flask_restplus is to set the SwaggerUiBundle.url to the full url, in which case when using port forwarding an address like this gets rendered and works find from the browser:

![image](https://user-images.githubusercontent.com/13764397/55720926-4b396d80-5a02-11e9-8c5a-017195da204f.png)
---
By overriding `flask_restplus.Api.specs_url` to return the relative URL, it fixes this problem by rendering the following:

![image](https://user-images.githubusercontent.com/13764397/55720982-7754ee80-5a02-11e9-95f8-0ad90d780217.png)
