### PR TITLE
Add pytest timeout with 100 sec timeout

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -7,3 +7,4 @@ flakes-ignore =
 filterwarnings =
     ignore::DeprecationWarning
     ignore::PendingDeprecationWarning
+timeout = 100

--- a/test_requirements.in
+++ b/test_requirements.in
@@ -3,6 +3,7 @@ pytest==4.0.0
 pytest-xdist==1.26.1  # Parallelises the test-runs
 ruamel.yaml==0.15.76
 pytest-mypy==0.3.2
+pytest-timeout~=1.3
 responses==0.10.5
 black==18.9b0
 pytest-flakes~=4.0

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -63,6 +63,7 @@ pytest-asyncio==0.10.0
 pytest-flakes==4.0.0
 pytest-forked==1.0.2      # via pytest-xdist
 pytest-mypy==0.3.2
+pytest-timeout==1.3.3
 pytest-xdist==1.26.1
 pytest==4.0.0
 python-dateutil==2.8.0    # via adal, jupyter-client


### PR DESCRIPTION
 Add pytest timeout with 100 sec timeout. It will kill any tests which take longer than 100 sec and provide a stacktrace