### PR TITLE
Change running of black tests to use os.system, update black

### DIFF
--- a/test_requirements.in
+++ b/test_requirements.in
@@ -5,7 +5,7 @@ ruamel.yaml==0.15.76
 pytest-mypy==0.3.2
 pytest-timeout~=1.3
 responses==0.10.5
-black==18.9b0
+black==19.3b0
 pytest-flakes~=4.0
 adal~=1.2
 jupyter==1.0.0

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -12,7 +12,7 @@ asynctest==0.12.4
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via black, jsonschema, pytest
 backcall==0.1.0           # via ipython
-black==18.9b0
+black==19.3b0
 bleach==3.1.0             # via nbconvert
 certifi==2019.3.9         # via requests
 cffi==1.12.3              # via cryptography

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -1,32 +1,24 @@
 # -*- coding: utf-8 -*-
 import os
+import sys
 import unittest
-import black
-from click.testing import CliRunner
 
 
 class FormattingTestCase(unittest.TestCase):
-    def test_project_formatting(self):
-        """
-        Test existing code would require no re-formatting
-        """
+    def test_formatting_black(self):
         project_path = os.path.join(os.path.dirname(__file__), "..")
         gordo_components_path = os.path.join(project_path, "gordo_components")
         tests_path = os.path.join(project_path, "tests")
-        runner = CliRunner()
-        resp = runner.invoke(
-            black.main,
-            [
-                "--check",
-                "-v",
-                gordo_components_path,
-                tests_path,
-                "--exclude",
-                r".*_version.py",
-            ],
-        )
-        self.assertEqual(
-            resp.exit_code,
-            0,
-            msg=f"Black would still reformat one or ore files:\n{resp.output} \n{resp.exc_info}",
-        )
+        cmd = [
+            sys.executable,
+            "-m",
+            "black",
+            "--check",
+            "-v",
+            gordo_components_path,
+            tests_path,
+            "--exclude",
+            r".*_version.py",
+        ]
+        exit_code = os.system(" ".join(cmd))
+        self.assertEqual(exit_code, 0)


### PR DESCRIPTION
The CLI runner together with black seems to be a bit unstable, suggest using os.system for a maybe more predictable running.