### PR TITLE
Add ability to have template variables in model config

### DIFF
--- a/gordo_components/cli/client.py
+++ b/gordo_components/cli/client.py
@@ -11,18 +11,14 @@ import click
 import pandas as pd  # noqa
 
 from gordo_components.client import Client
-from gordo_components.client.client import EndpointMetadata  # noqa
 from gordo_components import serializer
 from gordo_components.data_provider import providers
-from gordo_components.cli.custom_types import IsoFormatDateTime, DataProviderParam
+from gordo_components.cli.custom_types import (
+    IsoFormatDateTime,
+    DataProviderParam,
+    key_value_par,
+)
 from gordo_components.client.forwarders import ForwardPredictionsIntoInflux
-
-
-def key_value_par(val) -> typing.Tuple[str, str]:
-    """
-    Helpder for CLI input of 'key,val'
-    """
-    return val.split(",")
 
 
 @click.group("client")

--- a/gordo_components/cli/custom_types.py
+++ b/gordo_components/cli/custom_types.py
@@ -3,6 +3,8 @@
 import os
 import json
 import ast
+import typing
+
 import click
 from dateutil import parser
 
@@ -46,3 +48,10 @@ class IsoFormatDateTime(click.ParamType):
             return parser.isoparse(value)
         except ValueError:
             self.fail(f"Failed to parse date '{value}' as ISO formatted date'")
+
+
+def key_value_par(val) -> typing.Tuple[str, str]:
+    """
+    Helpder for CLI input of 'key,val'
+    """
+    return val.split(",")

--- a/requirements.in
+++ b/requirements.in
@@ -2,6 +2,7 @@ Click~=7.0
 cachetools~=3.1
 h5py~=2.8
 influxdb~=5.2
+jinja2~=2.10
 joblib~=0.13
 Keras~=2.2
 numpy~=1.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ idna==2.8                 # via idna-ssl, requests, yarl
 imagesize==1.1.0          # via sphinx
 influxdb==5.2.2
 itsdangerous==1.1.0       # via flask
-jinja2==2.10.1            # via flask, sphinx
+jinja2==2.10.1
 joblib==0.13.2
 jsonschema==3.0.1         # via flask-restplus
 keras-applications==1.0.7  # via keras, tensorflow

--- a/tests/gordo_components/cli/test_cli.py
+++ b/tests/gordo_components/cli/test_cli.py
@@ -23,9 +23,7 @@ DATA_CONFIG = (
     "}"
 )
 
-MODEL_CONFIG = {
-    "gordo_components.model.models.KerasAutoEncoder": {"kind": "feedforward_hourglass"}
-}
+MODEL_CONFIG = {"sklearn.decomposition.pca.PCA": {"svd_solver": "auto"}}
 
 logger = logging.getLogger(__name__)
 

--- a/tests/gordo_components/cli/test_cli.py
+++ b/tests/gordo_components/cli/test_cli.py
@@ -5,9 +5,11 @@ import unittest
 import logging
 import tempfile
 
+import jinja2
 from click.testing import CliRunner
 
 from gordo_components import cli
+from gordo_components.cli.cli import expand_model, DEFAULT_MODEL_CONFIG
 from tests.utils import temp_env_vars
 
 import json
@@ -128,3 +130,57 @@ class CliTestCase(unittest.TestCase):
             with open("/tmp/model-location.txt") as f:
                 second_path = f.read()
             assert first_path != second_path
+
+    def test_build_model_with_parameters(self):
+        """
+        It works to build a simple model with parameters set
+        """
+
+        model = """
+        {
+         "sklearn.decomposition.pca.PCA":
+          {
+            "svd_solver": "{{svd_solver}}",
+            "n_components": {{n_components}}
+          }
+        }
+        """
+
+        svd_solver = "auto"
+        n_components = 0.5
+
+        logger.info(f"MODEL_CONFIG={json.dumps(model)}")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with temp_env_vars(
+                OUTPUT_DIR=tmpdir, DATA_CONFIG=DATA_CONFIG, MODEL_CONFIG=model
+            ):
+                args = [
+                    "build",
+                    "--model-parameter",
+                    f"svd_solver,{svd_solver}",
+                    "--model-parameter",
+                    f"n_components,{n_components}",
+                ]
+                result = self.runner.invoke(cli.gordo, args=args)
+
+            self.assertEqual(result.exit_code, 0, msg=f"Command failed: {result}")
+            self.assertTrue(
+                os.path.exists("/tmp/model-location.txt"),
+                msg='Building was supposed to create a "model-location.txt", but it did not!',
+            )
+
+    def test_expand_model_default_works(self):
+        self.assertEquals(expand_model(DEFAULT_MODEL_CONFIG, {}), DEFAULT_MODEL_CONFIG)
+
+    def test_expand_model_expand_works(self):
+        model_params = {"kind": "hourglass", "num": 5}
+        model_template = "{'gordo_components.model.models.KerasAutoEncoder': {'kind': '{{kind}}', 'num': {{num}}}} "
+        expected_model = "{'gordo_components.model.models.KerasAutoEncoder': {'kind': 'hourglass', 'num': 5}} "
+        self.assertEquals(expand_model(model_template, model_params), expected_model)
+
+    def test_expand_model_complains_on_missing_vars(self):
+        model_params = {"kind": "hourglass"}
+        model_template = "{'gordo_components.model.models.KerasAutoEncoder': {'kind': '{{kind}}', 'num': {{num}}}} "
+        with self.assertRaises(ValueError):
+            expand_model(model_template, model_params)


### PR DESCRIPTION
This PR introduces a new option to model building  `--model-parameter`:
> Key-Value pair for a model parameter and its value, may use this option 
   multiple times. Separate key,valye by a comma. ie: --model-parameter key,val
   --model-parameter some_key,some_value

It also allows you to specify the model with jinja-holes in them. An example of a legal model is:
 ```yaml        {
         "sklearn.decomposition.pca.PCA":
          {
            "svd_solver": "{{svd_solver}}",
            "n_components": {{n_components}}
          }
        }
```
And this can then be built with e.g. ` --model-parameter svc_solver,auto --model-parameter n_components,0.5`.

I also found that by replacing Keras with PCA in the CLI tests we got a speedup from 20s to 0.2s, so  I added that as a separate commit. That is related to #253. 

This closes #241 .