### PR TITLE
Print vc scores

### DIFF
--- a/gordo_components/util/disk_registry.py
+++ b/gordo_components/util/disk_registry.py
@@ -82,3 +82,32 @@ def get_value(registry_dir: Union[os.PathLike, str], key: str) -> Optional[AnySt
     else:
         logger.info(f"Did not find registry key {key} at path {key_file_path}")
     return output_val
+
+
+def delete_value(registry_dir: Union[os.PathLike, str], key: str) -> bool:
+    """
+    Deletes the value with key `reg_key`from the registry, and returns True if it
+    existed.
+
+    Parameters
+    ----------
+    registry_dir: Union[os.PathLike, str]
+        Path to the registry. Does not need to exist
+    key: str
+        Key to look up in the registry.
+
+    Returns
+    -------
+    bool
+        True if the key existed, false otherwise
+    """
+    key_file_path = Path(registry_dir).joinpath(key)
+    logger.info(f"Looking for registry key {key} at path " f"{key_file_path}")
+    # If the model location exists
+    if key_file_path.exists():
+        key_file_path.unlink()
+        logger.debug(f"Removed key {key} from registry")
+        return True
+    else:
+        logger.info(f"Did not find registry key {key} at path {key_file_path}")
+    return False

--- a/tests/gordo_components/builder/test_builder.py
+++ b/tests/gordo_components/builder/test_builder.py
@@ -182,28 +182,39 @@ class ModelBuilderTestCase(unittest.TestCase):
 
 
 @pytest.mark.parametrize(
-    "should_be_equal,metadata,tag_list",
+    "should_be_equal,metadata,tag_list,replace_cache",
     [
-        (True, None, None),
-        (False, {"metadata": "something"}, None),
-        (False, None, [SensorTag("extra_tag", None)]),
+        (True, None, None, False),
+        (False, {"metadata": "something"}, None, False),
+        (False, None, [SensorTag("extra_tag", None)], False),
+        (False, None, None, True),  # replace_cache gives a new model location
     ],
 )
 def test_provide_saved_model_caching(
-    should_be_equal: bool, metadata: Optional[Dict], tag_list: Optional[List[SensorTag]]
+    should_be_equal: bool,
+    metadata: Optional[Dict],
+    tag_list: Optional[List[SensorTag]],
+    replace_cache,
 ):
     """
-    Test provide_saved_model with caching and possible cache busting if metadata or
-    tag_list is set.
+    Test provide_saved_model with caching and possible cache busting if metadata,
+    tag_list, or replace_cache is set.
+
+    Builds two models and checks if their locations are the same, which will be if and
+    only if there is caching.
 
     Parameters
     ----------
     should_be_equal : bool
-        Should the two generated models be at the same location or not?
+        Do we expect the two generated models to be at the same location or not? I.e. do
+        we expect caching.
     metadata
-        Optional metadata which will be used as metadata instead of the default
+        Optional metadata which will be used as metadata for the second model.
     tag_list
-        Possible list of strings which be used as the taglist in the dataset if provided
+        Optional list of strings which be used as the taglist in the dataset for the
+        second model.
+    replace_cache: bool
+        Should we force a model cache replacement?
 
     """
 
@@ -235,6 +246,7 @@ def test_provide_saved_model_caching(
             output_dir=new_output_dir,
             metadata=metadata,
             model_register_dir=registry_dir,
+            replace_cache=replace_cache,
         )
         if should_be_equal:
             assert model_location == model_location2

--- a/tests/gordo_components/util/test_disk_registry.py
+++ b/tests/gordo_components/util/test_disk_registry.py
@@ -43,3 +43,26 @@ def test_overwrites_existing():
         second_value = "Some value"
         disk_registry.write_key(tmpdir, the_key, second_value)
         assert disk_registry.get_value(tmpdir, the_key) == second_value
+
+
+def test_delete():
+    """Delete removes a key"""
+    the_key = "akey"
+    with tempfile.TemporaryDirectory() as tmpdir:
+        first_value = "Some value"
+        disk_registry.write_key(tmpdir, the_key, first_value)
+        assert disk_registry.get_value(tmpdir, the_key) == first_value
+
+        existed_p = disk_registry.delete_value(tmpdir, the_key)
+        assert disk_registry.get_value(tmpdir, the_key) is None
+        # They key existed
+        assert existed_p
+
+
+def test_double_delete():
+    """Delete works on non-existing key, returning False"""
+    the_key = "akey"
+    with tempfile.TemporaryDirectory() as tmpdir:
+        existed_p = disk_registry.delete_value(tmpdir, the_key)
+        assert disk_registry.get_value(tmpdir, the_key) is None
+        assert not existed_p


### PR DESCRIPTION
Prints out the cross validation scores on a katlib-readable format to stdout.
If we ask for CV printing but the loaded model from cache does not have that metadata stored then we delete it from the cache and rebuild the model. 

If/when we support doing CV with several choosen scoring methods this logic can be extended to rebuild the model in case at least one of them are not present.

This closes #243 .