### PR TITLE
Support KerasRawModelRegressor

### DIFF
--- a/gordo_components/model/models.py
+++ b/gordo_components/model/models.py
@@ -3,10 +3,12 @@
 import abc
 import logging
 import json
+import io
+import pickle
 
+from pprint import pprint
 from typing import Union, Callable, Dict, Any, Optional
 from os import path
-import pickle
 from abc import ABCMeta
 
 import tensorflow.keras.models
@@ -328,9 +330,6 @@ class KerasRawModelRegressor(KerasAutoEncoder):
         self.build_fn = lambda: self.keras_from_spec(self.kind)  # type: ignore
 
     def __repr__(self):
-        import io
-        from pprint import pprint
-
         stream = io.StringIO()
         pprint(self.kind, stream=stream)
         stream.seek(0)
@@ -339,6 +338,13 @@ class KerasRawModelRegressor(KerasAutoEncoder):
 
     @staticmethod
     def keras_from_spec(spec: dict):
+        _expected_keys = ("spec", "compile")
+        if not all(k in spec for k in _expected_keys):
+            raise ValueError(
+                f"Expected spec to have keys: {_expected_keys}, but found {spec.keys()}"
+            )
+        logger.debug(f"Building model from spec: {spec}")
+
         model = serializer.pipeline_from_definition(spec["spec"])
         model.compile(**spec["compile"])
         return model

--- a/gordo_components/serializer/pipeline_from_definition.py
+++ b/gordo_components/serializer/pipeline_from_definition.py
@@ -69,7 +69,7 @@ def _build_branch(
     leafs of the branch, if constructor_class is not none. Otherwise just the
     built leafs are returned.
     """
-    steps = [_build_step(step) for i, step in enumerate(definition)]
+    steps = [_build_step(step) for step in definition]
     return steps if constructor_class is None else constructor_class(steps)
 
 

--- a/gordo_components/serializer/pipeline_from_definition.py
+++ b/gordo_components/serializer/pipeline_from_definition.py
@@ -7,6 +7,7 @@ import typing  # noqa
 from typing import Union, Dict, Any, Iterable
 from sklearn.pipeline import Pipeline, FeatureUnion
 from sklearn.base import BaseEstimator
+from tensorflow.keras.models import Sequential
 
 
 logger = logging.getLogger(__name__)
@@ -64,9 +65,21 @@ def _build_branch(
     constructor_class=Union[Pipeline, None],
 ):
     """
-    Builds a branch of the tree and optionall constructs the class with the given
+    Builds a branch of the tree and optionally constructs the class with the given
     leafs of the branch, if constructor_class is not none. Otherwise just the
     built leafs are returned.
+    """
+    steps = [_build_step(step) for i, step in enumerate(definition)]
+    return steps if constructor_class is None else constructor_class(steps)
+
+
+def _build_scikit_branch(
+    definition: Iterable[Union[str, Dict[Any, Any]]],
+    constructor_class=Union[Pipeline, None],
+):
+    """
+    Exactly like :func:`~_build_branch` except it's expected this is going to
+    be a list of tuples, where the 0th element is the name of the step.
     """
     steps = [(f"step_{i}", _build_step(step)) for i, step in enumerate(definition)]
     return steps if constructor_class is None else constructor_class(steps)
@@ -80,21 +93,21 @@ def _build_step(
 
     Parameters
     ----------
-        step: dict/str - A dict, with a single key and associated dict
-                         where the associated dict are parameters for the
-                         given step.
+    step: dict/str - A dict, with a single key and associated dict
+                     where the associated dict are parameters for the
+                     given step.
 
-                         Example: {'sklearn.preprocessing.PCA':
-                                        {'n_components': 4}
-                                  }
-                            Gives:  PCA(n_components=4)
+                     Example: {'sklearn.preprocessing.PCA':
+                                    {'n_components': 4}
+                              }
+                        Gives:  PCA(n_components=4)
 
-                        Alternatively, 'step' can be a single string, in
-                        which case the step will be initiated w/ default
-                        params.
+                    Alternatively, 'step' can be a single string, in
+                    which case the step will be initiated w/ default
+                    params.
 
-                        Example: 'sklearn.preprocessing.PCA'
-                            Gives: PCA()
+                    Example: 'sklearn.preprocessing.PCA'
+                        Gives: PCA()
     Returns
     -------
         Scikit-Learn Transformer or BaseEstimator
@@ -126,31 +139,33 @@ def _build_step(
                     if callable(possible_func):
                         params[param] = possible_func
 
-        StepClass = pydoc.locate(
+        StepClass: Union[FeatureUnion, Pipeline, BaseEstimator] = pydoc.locate(
             import_str
-        )  # type: Union[FeatureUnion, Pipeline, BaseEstimator]
+        )
 
         if StepClass is None:
             raise ImportError(f'Could not locate path: "{import_str}"')
 
         # FeatureUnion or another Pipeline transformer
-        if any(StepClass == obj for obj in [FeatureUnion, Pipeline]):
+        if any(StepClass == obj for obj in [FeatureUnion, Pipeline, Sequential]):
 
             # Need to ensure the parameters to be supplied are valid FeatureUnion
             # & Pipeline both take a list of transformers, but with different
-            # kwarg, here we pull out the list to keep _build_branch generic
+            # kwarg, here we pull out the list to keep _build_scikit_branch generic
             if "transformer_list" in params:
-                params["transformer_list"] = _build_branch(
+                params["transformer_list"] = _build_scikit_branch(
                     params["transformer_list"], None
                 )
             elif "steps" in params:
-                params["steps"] = _build_branch(params["steps"], None)
+                params["steps"] = _build_scikit_branch(params["steps"], None)
 
             # If params is an iterable, is has to be the first argument
             # to the StepClass (FeatureUnion / Pipeline); a list of transformers
             elif any(isinstance(params, obj) for obj in (tuple, list)):
-                steps = _build_branch(params, None)
+                steps = _build_scikit_branch(params, None)
                 return StepClass(steps)
+            elif isinstance(params, dict) and "layers" in params:
+                params["layers"] = _build_branch(params["layers"], None)
             else:
                 raise ValueError(
                     f"Got {StepClass} but the supplied parameters"
@@ -241,13 +256,9 @@ def _load_param_classes(params: dict):
             and isinstance(value[list(value.keys())[0]], dict)
         ):
             Model = pydoc.locate(list(value.keys())[0])
-            if (
-                Model is not None
-                and isinstance(Model, type)
-                and issubclass(Model, BaseEstimator)
-            ):
+            if Model is not None and isinstance(Model, type):
 
-                if issubclass(Model, Pipeline):
+                if issubclass(Model, Pipeline) or issubclass(Model, Sequential):
                     # Model is a Pipeline, so 'value' is the definition of that Pipeline
                     # Can can just re-use the entry to building a pipeline.
                     params[key] = pipeline_from_definition(value)

--- a/tests/gordo_components/model/test_raw_keras.py
+++ b/tests/gordo_components/model/test_raw_keras.py
@@ -1,0 +1,89 @@
+import pytest
+import yaml
+import tensorflow as tf
+import numpy as np
+from sklearn.pipeline import Pipeline
+
+from gordo_components import serializer
+from gordo_components.model.models import KerasRawModelRegressor
+
+
+@pytest.mark.parametrize(
+    "spec_str",
+    (
+        """
+        compile:
+            loss: mse
+            optimizer: sgd
+        spec:
+            tensorflow.keras.models.Sequential:
+                layers:
+                    - tensorflow.keras.layers.Dense: 
+                        units: 10
+                    - tensorflow.keras.layers.Dense:
+                        units: 32
+                        kernel_regularizer:
+                            tensorflow.keras.regularizers.L1L2:
+                                l1: 0.2
+                    - tensorflow.keras.layers.Dense:
+                        units: 1
+    """,
+        """
+        compile:
+            loss: mse
+            optimizer: adam
+        spec:
+            tensorflow.keras.models.Sequential:
+                layers:
+                    - tensorflow.keras.layers.Input:
+                        shape: [9]
+                    - tensorflow.keras.layers.Reshape:
+                        target_shape: [3, 3]
+                    - tensorflow.keras.layers.LSTM:
+                        units: 12
+                    - tensorflow.keras.layers.Flatten
+                    - tensorflow.keras.layers.Dense:
+                        units: 1
+    """,
+    ),
+)
+def test_raw_keras_basic(spec_str: str):
+    """
+    Can load a keras.Sequential model from a config/yaml definition(s)
+    """
+    spec = yaml.safe_load(spec_str)
+    model = KerasRawModelRegressor.keras_from_spec(spec)
+    assert isinstance(model, tf.keras.models.Sequential)
+
+
+def test_raw_keras_part_of_pipeline():
+    """
+    It should play well, when tucked into a sklearn.pipeline.Pipeline
+    """
+    X, y = np.random.random((100, 4)), np.random.random((100, 1))
+
+    config_str = """
+    sklearn.pipeline.Pipeline:
+        steps:
+            - sklearn.decomposition.pca.PCA:
+                n_components: 4
+            - gordo_components.model.models.KerasRawModelRegressor:
+                kind:
+                    compile:
+                        loss: mse
+                        optimizer: adam
+                    spec:
+                        tensorflow.keras.models.Sequential:
+                            layers:
+                                - tensorflow.keras.layers.Dense:
+                                    units: 4
+                                - tensorflow.keras.layers.Dense:
+                                    units: 1
+    """
+    config = yaml.safe_load(config_str)
+    pipe = serializer.pipeline_from_definition(config)
+    assert isinstance(pipe, Pipeline)
+
+    pipe.fit(X, y)
+    out = pipe.predict(X)
+    assert len(out) == len(y)


### PR DESCRIPTION
Problem :cat2: 
---
To support new Keras models, we need people to create a function in factories, which returns a model. 

This may be good for quite specialized cases, but there is the continual problem of exposing certain parameters of that model out into the factory function/config file.

Not to mention the development time of getting code into the project.

Solution :dog2: 
---
Thanks to our (mostly) robust serializer, only minor modifications are needed to allow people to specify the architecture of the keras model _directly_ in the config file.

This may also play better with the concept of #467 such that it could dynamically create the model definition more explicitly. :man_shrugging: 

Example
```yaml
sklearn.pipeline.Pipeline:
  steps:
    - sklearn.decomposition.pca.PCA:
        n_components: 4
    - gordo_components.model.models.KerasRawModel:
        kind:
          compile:
            loss: mse
            optimizer: sgd
            lr: 0.001
          spec:
            tensorflow.keras.models.Sequential:
              layers:
                - tensorflow.keras.layers.Dense: 
                    units: 4
                - tensorflow.keras.layers.Dense:
                    units: 32
                    kernel_regularizer:
                      tensorflow.keras.regularizers.L1L2:
                        l1: 0.2
                - tensorflow.keras.layers.Dropout:
                    rate: 0.2
                - tensorflow.keras.layers.Dense:
                    units: 1
```